### PR TITLE
feat: Implementa filtri reattivi per l'intera dashboard

### DIFF
--- a/backend/app/Controllers/trades_controller.py
+++ b/backend/app/Controllers/trades_controller.py
@@ -202,11 +202,12 @@ class TradesController:
         user_id: UUID = Query(..., description="ID utente"),
         start_date: Optional[date] = Query(None, description="Data inizio (YYYY-MM-DD)"),
         end_date: Optional[date] = Query(None, description="Data fine (YYYY-MM-DD)"),
+        setups: Optional[List[str]] = Query(None, alias="setups[]", description="Filtra per setup specifici"),
         db: AsyncSession = Depends(get_db),
     ) -> list[dict]:
         repo = TradeRepository(db)
         return await repo.get_calendar_data(
-            user_id=user_id, start_date=start_date, end_date=end_date
+            user_id=user_id, start_date=start_date, end_date=end_date, setups=setups
         )
 
     # --------------------------

--- a/backend/app/Repositories/trade_repository.py
+++ b/backend/app/Repositories/trade_repository.py
@@ -367,11 +367,12 @@ class TradeRepository:
         user_id: UUID,
         start_date: Optional[date] = None,
         end_date: Optional[date] = None,
+        setups: Optional[List[str]] = None,
     ) -> List[dict]:
         """
         Restituisce dati aggregati per giorno per il calendario.
         Per ogni giorno con trade, calcola: P&L totale, numero di trade, e numero di trade vincenti.
-        Filtra per un intervallo di date se fornito.
+        Filtra per un intervallo di date e per setup, se forniti.
         """
         day_alias = func.date_trunc("day", Trade.entry_timestamp).label("day")
         q = (
@@ -389,6 +390,8 @@ class TradeRepository:
             q = q.where(func.date(Trade.entry_timestamp) >= start_date)
         if end_date:
             q = q.where(func.date(Trade.entry_timestamp) <= end_date)
+        if setups:
+            q = q.where(Trade.setup.in_(setups))
 
         q = q.group_by(day_alias).order_by(day_alias.asc())
         res = await self.db.execute(q)

--- a/frontend/src/stores/trades.js
+++ b/frontend/src/stores/trades.js
@@ -493,8 +493,9 @@ export const useTradesStore = defineStore('trades', {
         end_date: filterStore.endDate?.toISOString().split('T')[0],
       };
 
-      // Il calendario non dovrebbe essere filtrato per setup, ma solo per data.
-      // Quindi non aggiungiamo il parametro 'setups'.
+      if (filterStore.selectedStrategy && filterStore.selectedStrategy.toLowerCase() !== 'all') {
+        params.setups = [filterStore.selectedStrategy];
+      }
 
       try {
         const response = await apiClient.get('/api/v1/trades/calendar/data', { params });


### PR DESCRIPTION
Estende la funzionalità di filtro (per data e setup) a tutti i componenti della dashboard, inclusi le schede statistiche, il calendario e i grafici, e corregge diverse regressioni introdotte durante lo sviluppo.

Backend:
- Aggiorna gli endpoint `performance/metrics` e `calendar/data` per accettare i parametri di filtro.
- Aggiorna il repository per applicare i filtri alle query del database.
- Aggiunge un alias al parametro 'setups' nel controller per correggere un problema di parsing con gli array inviati dal frontend.

Frontend:
- Aggiorna le azioni dello store (`fetchDashboardStats`, `fetchCalendarData`) per inviare i filtri correnti al backend.
- Modifica il watcher nella `DashboardView` per ricaricare tutti i dati quando i filtri cambiano.
- Corregge e ridisegna il componente `RecentTradesTable`.
- Corregge un bug nel `CalendarHeatmap` che causava un crash al click.
- Corregge un bug nel modale di riepilogo giornaliero ripristinando il calcolo delle statistiche.
- Corregge la logica di invio del filtro per la strategia "All".