### PR TITLE
Refactor: Remove redundant frontend filtering

### DIFF
--- a/frontend/src/components/dashboard/RecentTradesTable.vue
+++ b/frontend/src/components/dashboard/RecentTradesTable.vue
@@ -21,11 +21,11 @@ const headers = [
   { key: 'date', text: 'Date' },
 ];
 
-// Proprietà calcolata per ottenere solo i trade più recenti *filtrati*.
-// Questo risolve il warning e rende la tabella reattiva ai filtri.
-const recentFilteredTrades = computed(() => {
-  // .slice(0, 7) prende al massimo i primi 7 trade più recenti.
-  return tradesStore.filteredTrades.slice(0, 7);
+// Proprietà calcolata per ottenere solo i trade più recenti.
+// La lista dei trade nello store è già filtrata dal backend.
+const recentTrades = computed(() => {
+  // .slice(0, 7) prende al massimo i primi 7 trade.
+  return tradesStore.trades.slice(0, 7);
 });
 </script>
 
@@ -36,7 +36,7 @@ const recentFilteredTrades = computed(() => {
       <span class="widget-subtitle">Last 7 filtered trades</span>
     </div>
     <div class="table-container">
-      <BaseTable :headers="headers" :items="recentFilteredTrades">
+      <BaseTable :headers="headers" :items="recentTrades">
         <!-- Slot per formattare la colonna P&L -->
         <template #pnl="{ item }">
           <span :class="item.pnl >= 0 ? 'pnl-positive' : 'pnl-negative'">
@@ -48,7 +48,7 @@ const recentFilteredTrades = computed(() => {
           {{ new Date(item.date).toLocaleDateString() }}
         </template>
       </BaseTable>
-      <div v-if="recentFilteredTrades.length === 0" class="no-trades-message">
+      <div v-if="recentTrades.length === 0" class="no-trades-message">
         <p>No recent trades match the current filters.</p>
       </div>
     </div>

--- a/frontend/src/stores/trades.js
+++ b/frontend/src/stores/trades.js
@@ -50,39 +50,9 @@ export const useTradesStore = defineStore('trades', {
       return ['All', ...state.setups];
     },
 
-    filteredTrades: (state) => {
-      const filterStore = useFilterStore();
-      let trades = state.trades;
-
-      // Helper per formattare una data in YYYY-MM-DD per un confronto stringa affidabile
-      const toYYYYMMDD = (date) => {
-        const d = new Date(date);
-        const year = d.getFullYear();
-        const month = String(d.getMonth() + 1).padStart(2, '0');
-        const day = String(d.getDate()).padStart(2, '0');
-        return `${year}-${month}-${day}`;
-      };
-
-      if (filterStore.startDate && filterStore.endDate) {
-        const startStr = toYYYYMMDD(filterStore.startDate);
-        const endStr = toYYYYMMDD(filterStore.endDate);
-
-        trades = trades.filter(trade => {
-          // Estrae la parte YYYY-MM-DD dal timestamp del trade (es. "2023-10-27T10:00:00")
-          const tradeDateStr = trade.date.substring(0, 10);
-          return tradeDateStr >= startStr && tradeDateStr <= endStr;
-        });
-      }
-
-      if (filterStore.selectedStrategy && filterStore.selectedStrategy.toLowerCase() !== 'all') {
-        trades = trades.filter(trade => trade.strategy === filterStore.selectedStrategy);
-      }
-      return trades;
-    },
-
     processedData(state) {
-      const trades = this.filteredTrades;
       const filterStore = useFilterStore();
+      const trades = state.trades;
       const viewDateForCalendar = new Date(filterStore.endDate);
 
       const stats = { totalPnl: 0, tradeCount: 0, winningTrades: 0, losingTrades: 0, breakEvenTrades: 0, grossProfit: 0, grossLoss: 0, totalRisk: 0 };
@@ -307,8 +277,8 @@ export const useTradesStore = defineStore('trades', {
     },
 
     equityCurveData(state) {
-      if (this.filteredTrades.length === 0) return { labels: [], data: [] };
-      const sortedTrades = [...this.filteredTrades].sort((a, b) => new Date(a.date) - new Date(b.date));
+      if (state.trades.length === 0) return { labels: [], data: [] };
+      const sortedTrades = [...state.trades].sort((a, b) => new Date(a.date) - new Date(b.date));
       let cumulativePnl = 0;
       const dataPoints = sortedTrades.map(trade => {
         cumulativePnl += trade.pnl;
@@ -332,7 +302,7 @@ export const useTradesStore = defineStore('trades', {
 
       const monthLabel = viewDate.toLocaleString('en-US', { month: 'long', year: 'numeric' });
       let monthlyPnl = 0;
-      for (const trade of this.filteredTrades) {
+      for (const trade of this.trades) {
         const tradeDate = new Date(trade.date);
         if (tradeDate.getFullYear() === viewDate.getFullYear() && tradeDate.getMonth() === viewDate.getMonth()) {
           monthlyPnl += trade.pnl;


### PR DESCRIPTION
This refactoring removes the `filteredTrades` getter from the `trades.js` Pinia store. This getter was performing filtering on the client-side, which was redundant because the backend API already returns data filtered by date and strategy.

Changes:
- Deleted the `filteredTrades` getter in `frontend/src/stores/trades.js`.
- Updated all dependent getters (`processedData`, `equityCurveData`, `calendarControlsData`) within the same store to use the `trades` state property directly.
- Updated the `RecentTradesTable.vue` component to use `tradesStore.trades` instead of `tradesStore.filteredTrades`.

This change simplifies the frontend codebase, improves performance by avoiding unnecessary client-side processing, and makes the `trades` state the single source of truth for filtered data, as intended.