### PR TITLE
fix(charts): Force chart re-render on sidebar toggle

### DIFF
--- a/frontend/src/components/dashboard/DailyPnlChart.vue
+++ b/frontend/src/components/dashboard/DailyPnlChart.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { Line } from 'vue-chartjs';
 import {
   Chart as ChartJS,
@@ -11,6 +11,7 @@ import {
   Filler,
   Legend,
 } from 'chart.js';
+import { useUiStore } from '../../stores/uiStore';
 
 ChartJS.register(
   CategoryScale,
@@ -21,6 +22,13 @@ ChartJS.register(
   Filler,
   Legend
 );
+
+const uiStore = useUiStore();
+const chartKey = ref(0);
+
+watch(() => uiStore.isSidebarCollapsed, () => {
+  chartKey.value++;
+});
 
 const props = defineProps({
   chartData: {
@@ -118,7 +126,7 @@ const hasData = computed(() => {
 
 <template>
   <div class="chart-container">
-    <Line v-if="hasData" :data="data" :options="chartOptions" />
+    <Line v-if="hasData" :data="data" :options="chartOptions" :key="chartKey" />
     <div v-else class="chart-placeholder">
       <p>No trades to display.</p>
     </div>

--- a/frontend/src/components/dashboard/EquityCurveChart.vue
+++ b/frontend/src/components/dashboard/EquityCurveChart.vue
@@ -8,7 +8,7 @@
 -->
 
 <script setup>
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { Line } from 'vue-chartjs';
 import {
   Chart as ChartJS,
@@ -22,6 +22,7 @@ import {
   Filler, // Importato per poter colorare l'area sotto la linea
 } from 'chart.js';
 import { useTradesStore } from '../../stores/trades';
+import { useUiStore } from '../../stores/uiStore';
 
 // Registriamo i componenti di Chart.js che useremo.
 ChartJS.register(
@@ -34,6 +35,13 @@ ChartJS.register(
   Legend,
   Filler
 );
+
+const uiStore = useUiStore();
+const chartKey = ref(0);
+
+watch(() => uiStore.isSidebarCollapsed, () => {
+  chartKey.value++;
+});
 
 const tradesStore = useTradesStore();
 
@@ -105,7 +113,7 @@ const hasData = computed(() => {
       <h2 class="chart-title">Equity Curve</h2>
     </div>
     <div class="chart-container">
-      <Line v-if="hasData" :data="chartData" :options="chartOptions" />
+      <Line v-if="hasData" :data="chartData" :options="chartOptions" :key="chartKey" />
       <div v-else class="chart-placeholder">
         <p class="placeholder-text">No trading data available for the selected period.</p>
       </div>

--- a/frontend/src/components/dashboard/GaugeChart.vue
+++ b/frontend/src/components/dashboard/GaugeChart.vue
@@ -1,10 +1,18 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { Doughnut } from 'vue-chartjs';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 import { useChartColors } from '../../composables/useChartColors';
+import { useUiStore } from '../../stores/uiStore';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
+
+const uiStore = useUiStore();
+const chartKey = ref(0);
+
+watch(() => uiStore.isSidebarCollapsed, () => {
+  chartKey.value++;
+});
 
 const props = defineProps({
   value: {
@@ -61,7 +69,7 @@ const chartOptions = computed(() => ({
 
 <template>
   <div class="gauge-chart-container">
-    <Doughnut v-if="isReady" :data="chartData" :options="chartOptions" />
+    <Doughnut v-if="isReady" :data="chartData" :options="chartOptions" :key="chartKey" />
   </div>
 </template>
 

--- a/frontend/src/components/dashboard/RrDistributionWidget.vue
+++ b/frontend/src/components/dashboard/RrDistributionWidget.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { Bar } from 'vue-chartjs';
 import {
   Chart as ChartJS,
@@ -11,6 +11,7 @@ import {
   Legend,
 } from 'chart.js';
 import { useTradesStore } from '../../stores/trades';
+import { useUiStore } from '../../stores/uiStore';
 import { useChartColors } from '../../composables/useChartColors';
 
 ChartJS.register(
@@ -21,6 +22,13 @@ ChartJS.register(
   Tooltip,
   Legend
 );
+
+const uiStore = useUiStore();
+const chartKey = ref(0);
+
+watch(() => uiStore.isSidebarCollapsed, () => {
+  chartKey.value++;
+});
 
 const tradesStore = useTradesStore();
 const { feedbackColors, gridColors, isReady } = useChartColors();
@@ -114,7 +122,7 @@ const chartOptions = computed(() => ({
     </div>
     <div class="widget-content">
       <div class="chart-container">
-        <Bar v-if="isReady" :data="chartData" :options="chartOptions" />
+        <Bar v-if="isReady" :data="chartData" :options="chartOptions" :key="chartKey" />
       </div>
     </div>
   </div>

--- a/frontend/src/components/dashboard/VantageScoreWidget.vue
+++ b/frontend/src/components/dashboard/VantageScoreWidget.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { Radar } from 'vue-chartjs';
 import {
   Chart as ChartJS,
@@ -11,6 +11,7 @@ import {
   Legend,
 } from 'chart.js';
 import { useTradesStore } from '../../stores/trades';
+import { useUiStore } from '../../stores/uiStore';
 import { useChartColors } from '../../composables/useChartColors';
 
 ChartJS.register(
@@ -21,6 +22,13 @@ ChartJS.register(
   Tooltip,
   Legend
 );
+
+const uiStore = useUiStore();
+const chartKey = ref(0);
+
+watch(() => uiStore.isSidebarCollapsed, () => {
+  chartKey.value++;
+});
 
 const tradesStore = useTradesStore();
 const { radarColors } = useChartColors();
@@ -101,7 +109,7 @@ const score = computed(() => vantageScoreData.value?.score || 0);
     </div>
     <div class="widget-content">
       <div class="chart-container">
-        <Radar :data="chartData" :options="chartOptions" />
+        <Radar :data="chartData" :options="chartOptions" :key="chartKey" />
       </div>
       <div class="score-container">
         <span class="score-label">Your Zella Score</span>

--- a/frontend/src/components/dashboard/WinLossDonutChart.vue
+++ b/frontend/src/components/dashboard/WinLossDonutChart.vue
@@ -1,10 +1,18 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { Doughnut } from 'vue-chartjs';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 import { useChartColors } from '../../composables/useChartColors';
+import { useUiStore } from '../../stores/uiStore';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
+
+const uiStore = useUiStore();
+const chartKey = ref(0);
+
+watch(() => uiStore.isSidebarCollapsed, () => {
+  chartKey.value++;
+});
 
 // ✅ default a 0 per evitare undefined/NaN
 const props = defineProps({
@@ -60,7 +68,7 @@ const chartOptions = computed(() => ({
 <template>
   <div class="donut-chart-container">
     <!-- ✅ niente NaN: renderizza solo se pronto e c'è almeno 1 valore // evitato errore props in console-->
-    <Doughnut v-if="isReady && total > 0" :data="chartData" :options="chartOptions" />
+    <Doughnut v-if="isReady && total > 0" :data="chartData" :options="chartOptions" :key="chartKey" />
   </div>
 </template>
 


### PR DESCRIPTION
The chart components were not recalculating their dimensions when the sidebar was reopened, causing them to overflow their containers and trigger a horizontal scrollbar.

This commit fixes the issue by watching for changes in the sidebar's collapsed state (`uiStore.isSidebarCollapsed`). When the state changes, a reactive `key` is updated on each chart component. Changing the key forces Vue to destroy and re-create the component, which in turn forces Chart.js to re-render and correctly adapt to its new container size.

This fix is applied to all chart components in the dashboard:
- VantageScoreWidget
- EquityCurveChart
- DailyPnlChart
- GaugeChart
- RrDistributionWidget
- WinLossDonutChart