### PR TITLE
Fix calendar week numbers and modal dates

### DIFF
--- a/frontend/src/components/dashboard/DailySummaryModal.vue
+++ b/frontend/src/components/dashboard/DailySummaryModal.vue
@@ -27,8 +27,8 @@ const pnlStyle = (pnl) => {
 };
 
 const formattedDate = computed(() => {
-  if (!summaryData.value) return '';
-  const date = new Date(summaryData.value.startDate + 'T00:00:00');
+  if (!summaryData.value || !summaryData.value.startDate) return '';
+  const date = new Date(summaryData.value.startDate);
   return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
 });
 

--- a/frontend/src/components/dashboard/WeeklySummaryModal.vue
+++ b/frontend/src/components/dashboard/WeeklySummaryModal.vue
@@ -28,8 +28,8 @@ const pnlStyle = (pnl) => {
 
 const formattedDateRange = computed(() => {
   if (!summaryData.value || !summaryData.value.startDate || !summaryData.value.endDate) return '';
-  const start = new Date(summaryData.value.startDate + 'T00:00:00');
-  const end = new Date(summaryData.value.endDate + 'T00:00:00');
+  const start = new Date(summaryData.value.startDate);
+  const end = new Date(summaryData.value.endDate);
   const startMonth = start.toLocaleDateString('en-US', { month: 'short' });
   const endMonth = end.toLocaleDateString('en-US', { month: 'short' });
 

--- a/frontend/src/stores/trades.js
+++ b/frontend/src/stores/trades.js
@@ -244,11 +244,9 @@ export const useTradesStore = defineStore('trades', {
           const isoWeekKey = getISOWeekString(new Date(firstDayOfWeek.fullDate));
           const backendSummary = this.processedStats.weekly_totals[isoWeekKey];
           if (backendSummary) {
-            summary = {
-              weekNumber: parseInt(isoWeekKey.split('-W')[1], 10),
-              totalPnl: backendSummary.total_pnl,
-              tradingDaysCount: backendSummary.trading_days,
-            };
+            // Mantieni il weekNumber calcolato localmente, aggiorna solo i dati dal backend.
+            summary.totalPnl = backendSummary.total_pnl;
+            summary.tradingDaysCount = backendSummary.trading_days;
           }
         }
         weeklySummaries.push(summary);


### PR DESCRIPTION
- The calendar week summary now correctly displays the week of the month (e.g., "Week 2") instead of the ISO week of the year.
- The daily and weekly summary modals now correctly display the selected date or date range. This was fixed by correcting how Date objects are handled in the modal components.