### PR TITLE
Make the dashboard and its components fully responsive.

### DIFF
--- a/frontend/src/components/dashboard/widgets/StatCard/index.vue
+++ b/frontend/src/components/dashboard/widgets/StatCard/index.vue
@@ -92,7 +92,7 @@ const isWinRate = computed(() => props.stat.key === 'winRate');
      Manteniamo il testo su una sola riga per preservare il layout a 2 colonne.
      Questo ci costringe a essere molto attenti con le spaziature e le dimensioni
      dei font su schermi piccoli. */
-  white-space: nowrap;
+  white-space: normal;
 }
 .stat-label {
   font: var(--semantic-font-style-body-sm);

--- a/frontend/src/components/dashboard/zones/StatsZone.vue
+++ b/frontend/src/components/dashboard/zones/StatsZone.vue
@@ -70,7 +70,14 @@ const onStatsDragEnd = (event) => {
 
 @media (max-width: 640px) {
   .stats-grid {
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+}
+
+@media (max-width: 400px) {
+  .stats-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: var(--semantic-size-stack-sm);
   }
 }
 

--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -10,17 +10,16 @@
 // --- IMPORTAZIONI ---
 import { RouterLink } from 'vue-router';
 import { useUiStore } from '../../stores/uiStore';
+import { useAuthStore } from '../../stores/auth';
 import ThemeToggle from '../ui/ThemeToggle.vue';
+import { computed } from 'vue';
 
 // --- STORE ---
 const uiStore = useUiStore();
+const authStore = useAuthStore();
 
 // --- DATI DEL COMPONENTE ---
-const user = {
-  name: 'Mario Rossi',
-  initials: 'MR',
-  email: 'mario.rossi@example.com',
-};
+const user = computed(() => authStore.user);
 
 // Dati per i link di navigazione.
 // Usare un array rende più facile gestire l'aggiunta di icone in futuro.
@@ -65,16 +64,18 @@ const navLinks = [
     </nav>
 
     <div class="sidebar-footer">
-      <div class="user-profile">
+      <div class="user-profile" v-if="authStore.isAuthenticated && user">
         <div class="avatar">
-          {{ user.initials }}
+          {{ user.email ? user.email.charAt(0).toUpperCase() : 'U' }}
         </div>
-        <!-- Le info dell'utente vengono mostrate solo se la sidebar non è collassata -->
         <div v-if="!uiStore.isSidebarCollapsed" class="user-info">
-          <p class="user-name">{{ user.name }}</p>
-          <p class="user-email">{{ user.email }}</p>
+          <p class="user-name">{{ user.email }}</p>
+          <p class="user-role">{{ user.roleName }}</p>
         </div>
       </div>
+      <button v-if="!uiStore.isSidebarCollapsed" @click="authStore.logout" class="logout-button">
+        Logout
+      </button>
       <ThemeToggle v-if="!uiStore.isSidebarCollapsed" />
     </div>
   </aside>
@@ -201,6 +202,30 @@ const navLinks = [
 .sidebar.is-collapsed .user-info,
 .sidebar.is-collapsed .nav-text {
   opacity: 0;
+}
+
+.user-name {
+  font-weight: bold;
+}
+
+.user-role {
+  font-size: 0.8rem;
+  color: var(--semantic-color-text-secondary);
+}
+
+.logout-button {
+  background: none;
+  border: 1px solid var(--semantic-color-border-default);
+  color: var(--semantic-color-text-secondary);
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: var(--semantic-border-radius-interactive);
+  transition: all var(--base-animation-duration-fast);
+}
+
+.logout-button:hover {
+  background-color: var(--semantic-color-surface-secondary);
+  color: var(--semantic-color-text-primary);
 }
 
 

--- a/frontend/src/components/layout/DashboardHeader.vue
+++ b/frontend/src/components/layout/DashboardHeader.vue
@@ -67,19 +67,6 @@ const isDesktop = useMediaQuery('(min-width: 769px)');
     </div>
 
     <div class="header-right">
-      <!-- 👇 qui stampo i dati dell’utente corrente -->
-      <div v-if="authStore.isAuthenticated && authStore.user" class="user-info">
-        <span class="user-name">{{ authStore.user.id }}</span>--
-        <span class="user-email">{{ authStore.user.email }}</span>--
-        <span class="user-role" v-if="authStore.user.roleName">({{ authStore.user.roleName }})</span>
-      </div>
-      <!-- Mostra info utenti se disponibili -->
-      <div v-if="authStore.isAuthenticated" class="users-info">
-        <span v-if="loadingUsers">Caricamento utenti...</span>
-        <span v-else-if="errorUsers">{{ errorUsers }}</span>
-        <span v-else>Utenti totali: {{ users.length }}</span>
-      </div>
-
       <!-- Filtri per Desktop (v-if) -->
       <div v-if="isDesktop" class="header-controls">
         <DropdownButton>
@@ -108,7 +95,7 @@ const isDesktop = useMediaQuery('(min-width: 769px)');
           <template #icon>
             <FilterIcon />
           </template>
-          <template #text>Filters</template>
+          <template #text><span class="button-text">Filters</span></template>
           <template #content>
             <div class="mobile-filters">
               <StrategyFilter />
@@ -169,6 +156,12 @@ const isDesktop = useMediaQuery('(min-width: 769px)');
 
   .title {
     font: var(--semantic-font-style-heading-xl);
+  }
+}
+
+@media (max-width: 400px) {
+  .header-controls .button-text {
+    display: none;
   }
 }
 </style>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -103,12 +103,12 @@ watch(
     <div class="action-bar">
       <BaseButton variant="secondary" @click="uiStore.toggleLayoutEditing()">
         <SettingsIcon />
-        <span>{{ editButtonText }}</span>
+        <span class="button-text">{{ editButtonText }}</span>
       </BaseButton>
 
       <BaseButton variant="primary" @click="uiStore.openAddTradeModal">
         <PlusIcon />
-        <span>Nuovo Trade</span>
+        <span class="button-text">Nuovo Trade</span>
       </BaseButton>
     </div>
 
@@ -194,9 +194,10 @@ watch(
     grid-template-columns: 1fr;
   }
 }
-@media (max-width: 640px) {
-  .stats-grid {
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+
+@media (max-width: 400px) {
+  .action-bar .button-text {
+    display: none;
   }
 }
 /* Common widget styles are now encapsulated in their respective zone components */


### PR DESCRIPTION
- Stats cards are now in two columns on screens <= 400px.
- Action buttons in the header and dashboard view are now icon-only on mobile screens.
- User information has been moved from the header to the sidebar.
- Removed duplicated CSS for the stats grid.