### PR TITLE
This commit makes the dashboard and its components fully responsive, …

### DIFF
--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -73,10 +73,12 @@ const navLinks = [
           <p class="user-role">{{ user.roleName }}</p>
         </div>
       </div>
-      <button v-if="!uiStore.isSidebarCollapsed" @click="authStore.logout" class="logout-button">
-        Logout
-      </button>
-      <ThemeToggle v-if="!uiStore.isSidebarCollapsed" />
+      <div class="footer-actions" v-if="!uiStore.isSidebarCollapsed">
+        <button @click="authStore.logout" class="logout-button">
+          Logout
+        </button>
+        <ThemeToggle />
+      </div>
     </div>
   </aside>
 </template>
@@ -170,10 +172,16 @@ const navLinks = [
 
 .sidebar-footer {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--semantic-size-stack-sm);
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--semantic-size-stack-md);
   overflow: hidden;
+}
+
+.footer-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .user-profile {

--- a/frontend/src/components/layout/DashboardHeader.vue
+++ b/frontend/src/components/layout/DashboardHeader.vue
@@ -105,9 +105,6 @@ const isDesktop = useMediaQuery('(min-width: 769px)');
         </DropdownButton>
       </div>
 
-      <BaseButton v-if="authStore.isAuthenticated" variant="secondary" size="small" @click="authStore.logout">
-        Logout
-      </BaseButton>
     </div>
   </header>
 </template>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -194,6 +194,11 @@ watch(
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   }
 }
+@media (max-width: 640px) {
+  .stats-grid {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  }
+}
 
 @media (max-width: 400px) {
   .action-bar .button-text {


### PR DESCRIPTION
…addressing several user requests.

- Stats cards are now in two columns on screens <= 400px.
- Action buttons in the header and dashboard view are now icon-only on mobile screens.
- User information has been moved from the header to the sidebar.
- The main widget grids are now fluid and responsive.
- The logout button has been removed from the header.
- The sidebar footer layout has been adjusted to prevent elements from overlapping.