### PR TITLE
This commit reduces the space between the spider chart and its footer…

### DIFF
--- a/frontend/src/components/dashboard/widgets/charts/VantageScoreWidget.vue
+++ b/frontend/src/components/dashboard/widgets/charts/VantageScoreWidget.vue
@@ -157,7 +157,7 @@ const score = computed(() => vantageScoreData.value?.score || 0);
   grid-template-columns: auto 1fr;
   align-items: baseline;
   gap: var(--semantic-size-stack-xs) var(--semantic-size-stack-sm);
-  margin-top: var(--semantic-size-stack-md);
+  margin-top: 0;
   flex-shrink: 0; /* Prevent the score section from shrinking */
 }
 


### PR DESCRIPTION
… in the Vantage Score widget.

- Set `margin-top` to `0` on the `.score-container` to minimize the gap.