### PR TITLE
feat(dashboard): Implement selectable layout templates

### DIFF
--- a/frontend/src/components/dashboard/LayoutSelector.vue
+++ b/frontend/src/components/dashboard/LayoutSelector.vue
@@ -1,0 +1,55 @@
+<script setup>
+import { computed } from 'vue';
+import { useDashboardLayoutStore } from '../../stores/dashboardLayout';
+
+const dashboardLayoutStore = useDashboardLayoutStore();
+
+const availableLayouts = computed(() => {
+  const layouts = [{ id: 'custom', name: 'Mio Layout' }];
+  for (const templateId in dashboardLayoutStore.templates) {
+    layouts.push({
+      id: templateId,
+      name: dashboardLayoutStore.templates[templateId].name,
+    });
+  }
+  return layouts;
+});
+
+const selectedLayout = computed({
+  get: () => dashboardLayoutStore.activeLayoutId,
+  set: (value) => {
+    dashboardLayoutStore.setActiveLayout(value);
+  },
+});
+</script>
+
+<template>
+  <div class="layout-selector">
+    <label for="layout-select">Layout:</label>
+    <select id="layout-select" v-model="selectedLayout">
+      <option v-for="layout in availableLayouts" :key="layout.id" :value="layout.id">
+        {{ layout.name }}
+      </option>
+    </select>
+  </div>
+</template>
+
+<style scoped>
+.layout-selector {
+  display: flex;
+  align-items: center;
+  gap: var(--semantic-size-stack-sm);
+}
+label {
+  font: var(--semantic-font-style-body-md);
+  color: var(--semantic-color-text-secondary);
+}
+select {
+  padding: var(--semantic-size-inset-sm);
+  border-radius: var(--semantic-border-radius-md);
+  border: 1px solid var(--semantic-color-border-default);
+  background-color: var(--semantic-color-surface-primary);
+  color: var(--semantic-color-text-primary);
+  font: var(--semantic-font-style-body-md);
+}
+</style>

--- a/frontend/src/components/dashboard/zones/DashboardZone.vue
+++ b/frontend/src/components/dashboard/zones/DashboardZone.vue
@@ -20,7 +20,7 @@ const props = defineProps({
     required: true,
   },
   gridClass: {
-    type: String,
+    type: [String, Array, Object],
     default: '',
   },
   maxItems: {
@@ -30,6 +30,10 @@ const props = defineProps({
   allowedWidgets: {
     type: Array,
     default: () => [],
+  },
+  isTemplateActive: {
+    type: Boolean,
+    default: false,
   },
 });
 
@@ -45,6 +49,17 @@ const draggableList = computed({
 });
 
 const isEditing = computed(() => uiStore.isLayoutEditing);
+const isDraggable = computed(() => isEditing.value && !props.isTemplateActive);
+
+const getWidgetStyle = (widget) => {
+  if (props.isTemplateActive) {
+    return {
+      gridColumn: `${widget.x + 1} / span ${widget.w}`,
+      gridRow: `${widget.y + 1} / span ${widget.h}`,
+    };
+  }
+  return {};
+};
 
 const handleDragEnd = (event) => {
   emit('drag-end', { zone: props.zoneId, event });
@@ -68,13 +83,17 @@ const handleRemoveWidget = (widgetId) => {
       :class="['widget-grid', gridClass]"
       ghost-class="ghost"
       @end="handleDragEnd"
-      :disabled="!isEditing"
+      :disabled="!isDraggable"
     >
       <template #item="{ element: widget }">
-        <div class="widget-wrapper" :class="{ 'is-editing': isEditing }">
+        <div
+          class="widget-wrapper"
+          :class="{ 'is-editing': isEditing, 'is-draggable': isDraggable }"
+          :style="getWidgetStyle(widget)"
+        >
           <component :is="widgetComponents[widget.i]" />
           <button
-            v-if="isEditing"
+            v-if="isDraggable"
             class="remove-widget-btn"
             @click="handleRemoveWidget(widget.i)"
           >
@@ -85,7 +104,7 @@ const handleRemoveWidget = (widgetId) => {
       <template #footer>
         <div
           class="add-widget-wrapper"
-          v-if="isEditing && widgets.length < maxItems"
+          v-if="isDraggable && widgets.length < maxItems"
         >
           <PopoverMenu>
             <template #trigger="{ toggle }">
@@ -124,11 +143,11 @@ const handleRemoveWidget = (widgetId) => {
   position: relative;
 }
 
-.widget-wrapper.is-editing {
+.widget-wrapper.is-draggable {
   cursor: grab;
 }
 
-.widget-wrapper.is-editing:active {
+.widget-wrapper.is-draggable:active {
   cursor: grabbing;
 }
 

--- a/frontend/src/stores/dashboardLayout.js
+++ b/frontend/src/stores/dashboardLayout.js
@@ -13,6 +13,7 @@ export const useDashboardLayoutStore = defineStore('dashboardLayout', {
       charts: [],
       main: [],
     },
+    activeLayoutId: 'custom', // 'custom' or a template ID like 'template-1'
     isLoading: false,
     originalLayout: null,
     originalStats: null,
@@ -26,6 +27,27 @@ export const useDashboardLayoutStore = defineStore('dashboardLayout', {
         { i: 'calendar' },
         { i: 'recentTrades' },
       ],
+    },
+    templates: {
+      'template-1': {
+        name: 'Standard',
+        layout: {
+          // Based on a 12-column grid
+          stats: [
+            { i: 'netPnl', x: 0, y: 0, w: 3, h: 1 },
+            { i: 'winRate', x: 3, y: 0, w: 3, h: 1 },
+            { i: 'profitFactor', x: 6, y: 0, w: 3, h: 1 },
+            { i: 'trades', x: 9, y: 0, w: 3, h: 1 },
+          ],
+          charts: [
+            { i: 'cumulativePnl', x: 0, y: 0, w: 12, h: 1 },
+          ],
+          main: [
+            { i: 'calendar', x: 0, y: 0, w: 8, h: 2 },
+            { i: 'recentTrades', x: 8, y: 0, w: 4, h: 2 },
+          ]
+        }
+      }
     },
     widgetConfig: {
       charts: {
@@ -47,8 +69,18 @@ export const useDashboardLayoutStore = defineStore('dashboardLayout', {
   }),
 
   getters: {
+    isTemplateActive(state) {
+      return state.activeLayoutId !== 'custom';
+    },
+    activeLayout(state) {
+      if (state.activeLayoutId !== 'custom' && state.templates[state.activeLayoutId]) {
+        return state.templates[state.activeLayoutId].layout;
+      }
+      return state.layout;
+    },
     isDirty(state) {
-      if (!state.originalLayout || !state.originalStats) {
+      // Layout is only considered "dirty" if we are in custom mode
+      if (state.activeLayoutId !== 'custom' || !state.originalLayout || !state.originalStats) {
         return false; // Not in edit mode or no snapshot taken
       }
       const uiStore = useUiStore();
@@ -59,6 +91,9 @@ export const useDashboardLayoutStore = defineStore('dashboardLayout', {
   },
 
   actions: {
+    setActiveLayout(layoutId) {
+      this.activeLayoutId = layoutId;
+    },
     snapshotLayout() {
       const uiStore = useUiStore();
       this.originalLayout = JSON.parse(JSON.stringify(this.layout));
@@ -120,6 +155,9 @@ export const useDashboardLayoutStore = defineStore('dashboardLayout', {
     },
 
     async saveLayout() {
+      // Do not save if a template is active, templates are read-only.
+      if (this.activeLayoutId !== 'custom') return;
+
       const authStore = useAuthStore();
       if (!authStore.user) return;
       const uiStore = useUiStore();

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -12,6 +12,7 @@ import StatsZone from '../components/dashboard/zones/StatsZone.vue';
 import BaseButton from '../components/ui/BaseButton.vue';
 import SettingsIcon from '../components/icons/SettingsIcon.vue';
 import PlusIcon from '../components/icons/PlusIcon.vue';
+import LayoutSelector from '../components/dashboard/LayoutSelector.vue';
 import { useTradesStore } from '../stores/trades';
 import { useUiStore } from '../stores/uiStore';
 import { useFilterStore } from '../stores/filterStore';
@@ -44,7 +45,8 @@ const handleNewTrade = async (tradeData) => {
   }
 };
 
-const layout = computed(() => dashboardLayoutStore.layout);
+const layout = computed(() => dashboardLayoutStore.activeLayout);
+const isTemplateActive = computed(() => dashboardLayoutStore.isTemplateActive);
 
 const widgetComponents = {
   'vantageScore': VantageScoreWidget,
@@ -101,6 +103,7 @@ watch(
 <template>
   <div class="dashboard-view" :class="{ 'is-editing': uiStore.isLayoutEditing }">
     <div class="action-bar">
+      <LayoutSelector v-if="uiStore.isLayoutEditing" />
       <BaseButton variant="secondary" @click="uiStore.toggleLayoutEditing()">
         <SettingsIcon />
         <span class="button-text">{{ editButtonText }}</span>
@@ -120,7 +123,8 @@ watch(
       zone-id="charts"
       :widgets="layout.charts"
       :widget-components="widgetComponents"
-      grid-class="complex-widgets-grid"
+      :grid-class="['complex-widgets-grid', { 'grid-positional': isTemplateActive }]"
+      :is-template-active="isTemplateActive"
       :max-items="dashboardLayoutStore.widgetConfig.charts.max"
       :allowed-widgets="dashboardLayoutStore.widgetConfig.charts.allowed"
       @drag-end="onLayoutDragEnd"
@@ -133,7 +137,8 @@ watch(
       zone-id="main"
       :widgets="layout.main"
       :widget-components="widgetComponents"
-      grid-class="main-content-grid"
+      :grid-class="['main-content-grid', { 'grid-positional': isTemplateActive }]"
+      :is-template-active="isTemplateActive"
       :max-items="dashboardLayoutStore.widgetConfig.main.max"
       :allowed-widgets="dashboardLayoutStore.widgetConfig.main.allowed"
       @drag-end="onLayoutDragEnd"
@@ -189,10 +194,19 @@ watch(
 :deep(.main-content-grid) {
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
+
+:deep(.grid-positional) {
+  grid-template-columns: repeat(12, 1fr);
+}
+
 @media (max-width: 1280px) {
   :deep(.main-content-grid),
   :deep(.complex-widgets-grid) {
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+  /* Ensure positional grid also works on smaller screens if needed */
+  :deep(.grid-positional) {
+    grid-template-columns: repeat(12, 1fr);
   }
 }
 @media (max-width: 640px) {


### PR DESCRIPTION
This commit introduces a new feature allowing users to select from pre-defined, positional layout templates for their dashboard, in addition to their existing customizable grid.

Key changes:

- **Pinia Store (`useDashboardLayoutStore`):**
  - Added `activeLayoutId` state to track the current layout mode ('custom' vs. template ID).
  - Introduced a `templates` object to store definitions for positional layouts, using `{x, y, w, h}` coordinates.
  - Implemented `activeLayout` getter to dynamically serve the correct layout data to components.
  - The `saveLayout` action is now restricted to 'custom' mode, making templates read-only.

- **Components:**
  - Created a new `LayoutSelector.vue` component, enabling users to switch between their custom layout and the available templates.
  - Enhanced `DashboardZone.vue` to dynamically apply inline grid styles (`grid-column`, `grid-row`) based on the active template's data.
  - Drag-and-drop functionality and editing controls are now disabled when a template is active.

- **View & CSS:**
  - Updated `DashboardView.vue` to manage the layout state and apply a `grid-positional` class.
  - Added CSS for a 12-column grid system that underpins the new template layouts.