### PR TITLE
feat: Replace add trade modal with a dedicated page

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import DashboardView from '../views/DashboardView.vue';
+import AddTradeView from '../views/AddTradeView.vue';
 
 const router = createRouter({
   history: createWebHistory(),
@@ -16,6 +17,12 @@ const router = createRouter({
       name: 'dashboard',
       component: DashboardView,
       meta: { title: 'Dashboard' },
+    },
+    {
+      path: '/add-trade',
+      name: 'add-trade',
+      component: AddTradeView,
+      meta: { title: 'Add Trade' },
     },
     {
       path: '/trades',

--- a/frontend/src/stores/uiStore.js
+++ b/frontend/src/stores/uiStore.js
@@ -124,7 +124,6 @@ export const useUiStore = defineStore('ui', () => {
   // --- STATO E AZIONI PER I MODALI ---
   const isDailySummaryModalOpen = ref(false);
   const isWeeklySummaryModalOpen = ref(false);
-  const isAddTradeModalOpen = ref(false);
 
   // Salviamo lo stato della sidebar prima di aprire un modale
   let sidebarStateBeforeModal = false;
@@ -142,14 +141,6 @@ export const useUiStore = defineStore('ui', () => {
     if (!isMobile.value) {
       isSidebarCollapsed.value = sidebarStateBeforeModal;
     }
-  }
-
-  function openAddTradeModal() {
-    _openModal(isAddTradeModalOpen);
-  }
-
-  function closeAddTradeModal() {
-    _closeModal(isAddTradeModalOpen);
   }
 
   function openDailySummaryModal() {
@@ -214,7 +205,6 @@ export const useUiStore = defineStore('ui', () => {
     isCalendarWinRateVisible,
     isDailySummaryModalOpen,
     isWeeklySummaryModalOpen,
-    isAddTradeModalOpen,
 
     toggleLayoutEditing,
     toggleSidebar,
@@ -230,8 +220,6 @@ export const useUiStore = defineStore('ui', () => {
     closeDailySummaryModal,
     openWeeklySummaryModal,
     closeWeeklySummaryModal,
-    openAddTradeModal,
-    closeAddTradeModal,
 
     // Notifications
     notification,

--- a/frontend/src/views/AddTradeView.vue
+++ b/frontend/src/views/AddTradeView.vue
@@ -1,0 +1,135 @@
+<script setup>
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
+import BaseButton from '@/components/ui/BaseButton.vue';
+import NewTradeForm from '@/components/trades/NewTradeForm.vue';
+import { useTradesStore } from '@/stores/trades';
+import { useUiStore } from '@/stores/uiStore';
+
+const router = useRouter();
+const tradesStore = useTradesStore();
+const uiStore = useUiStore();
+
+const choice = ref(null); // can be 'manual' or 'import'
+
+const handleNewTrade = async (tradeData) => {
+  try {
+    const newTrade = await tradesStore.addTrade(tradeData);
+    if (newTrade) {
+      uiStore.showNotification({
+        message: 'Trade successfully created!',
+        type: 'success',
+      });
+      router.push('/trades');
+    }
+  } catch (error) {
+    console.error('Failed to add trade:', error);
+    const errorMessage = error.response?.data?.detail || 'An unknown error occurred.';
+    uiStore.showNotification({
+      message: `Error: ${errorMessage}`,
+      type: 'error',
+    });
+  }
+};
+</script>
+
+<template>
+  <div class="add-trade-view">
+    <h1 class="view-title">How do you want to add your trade?</h1>
+
+    <!-- Step 1: Choice -->
+    <div v-if="!choice" class="options-container">
+      <BaseButton
+        @click="choice = 'manual'"
+        class="base-button"
+      >
+        Manual
+      </BaseButton>
+      <BaseButton
+        @click="choice = 'import'"
+        class="base-button"
+        disabled
+      >
+        Import from Broker
+      </BaseButton>
+    </div>
+
+    <!-- Step 2: Form or Import UI -->
+    <div v-if="choice === 'manual'" class="form-container">
+       <BaseButton @click="choice = null" variant="secondary" class="back-button">
+        &larr; Go Back
+      </BaseButton>
+      <NewTradeForm @submit="handleNewTrade" />
+    </div>
+
+    <div v-if="choice === 'import'" class="import-container">
+       <BaseButton @click="choice = null" variant="secondary" class="back-button">
+        &larr; Go Back
+      </BaseButton>
+      <p>Import functionality is coming soon!</p>
+    </div>
+
+  </div>
+</template>
+
+<style scoped>
+.add-trade-view {
+  padding: var(--semantic-size-inset-xl);
+  display: flex;
+  flex-direction: column;
+  align-items: center; /* Center children horizontally */
+  gap: var(--semantic-size-stack-xl);
+  width: 100%;
+}
+
+.view-title {
+  font: var(--semantic-font-style-heading-h2);
+  color: var(--semantic-color-text-primary);
+  text-align: center;
+}
+
+.options-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--semantic-size-stack-md);
+  width: 100%;
+  max-width: 400px;
+}
+
+.base-button {
+  padding: var(--semantic-size-inset-xl);
+  font: var(--semantic-font-style-heading-h4);
+  transition: all 0.2s ease-in-out;
+}
+
+.base-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: var(--semantic-effect-shadow-lg);
+}
+
+.form-container,
+.import-container {
+  margin-top: var(--semantic-size-stack-lg);
+  width: 100%;
+  max-width: 900px; /* Adjust as needed */
+  background-color: var(--semantic-color-surface-primary);
+  padding: var(--semantic-size-inset-xl);
+  border-radius: var(--semantic-border-radius-container);
+  box-shadow: var(--semantic-effect-shadow-md);
+  position: relative;
+}
+
+.import-container {
+  display: grid;
+  place-items: center;
+  min-height: 200px;
+  color: var(--semantic-color-text-secondary);
+  font: var(--semantic-font-style-body-lg);
+}
+
+.back-button {
+  position: absolute;
+  top: var(--semantic-size-inset-md);
+  left: var(--semantic-size-inset-md);
+}
+</style>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -5,8 +5,6 @@ import RrDistributionWidget from '../components/dashboard/widgets/charts/RrDistr
 import CumulativePnlWidget from '../components/dashboard/widgets/charts/CumulativePnlWidget.vue';
 import CalendarHeatmap from '../components/dashboard/widgets/Calendar/CalendarHeatmap.vue';
 import RecentTradesTable from '../components/dashboard/widgets/Table/RecentTradesTable.vue';
-import BaseModal from '../components/ui/BaseModal.vue';
-import NewTradeForm from '../components/trades/NewTradeForm.vue';
 import DashboardZone from '../components/dashboard/zones/DashboardZone.vue';
 import StatsZone from '../components/dashboard/zones/StatsZone.vue';
 import BaseButton from '../components/ui/BaseButton.vue';
@@ -23,26 +21,6 @@ const tradesStore = useTradesStore();
 const uiStore = useUiStore();
 const filterStore = useFilterStore();
 const dashboardLayoutStore = useDashboardLayoutStore();
-
-const handleNewTrade = async (tradeData) => {
-  try {
-    const newTrade = await tradesStore.addTrade(tradeData);
-    if (newTrade) {
-      uiStore.closeAddTradeModal();
-      uiStore.showNotification({
-        message: 'Trade successfully created!',
-        type: 'success',
-      });
-    }
-  } catch (error) {
-    console.error('Failed to add trade:', error);
-    const errorMessage = error.response?.data?.detail || 'An unknown error occurred.';
-    uiStore.showNotification({
-      message: `Error: ${errorMessage}`,
-      type: 'error',
-    });
-  }
-};
 
 const layout = computed(() => dashboardLayoutStore.layout);
 
@@ -106,10 +84,12 @@ watch(
         <span class="button-text">{{ editButtonText }}</span>
       </BaseButton>
 
-      <BaseButton variant="primary" @click="uiStore.openAddTradeModal">
-        <PlusIcon />
-        <span class="button-text">Nuovo Trade</span>
-      </BaseButton>
+      <router-link to="/add-trade" custom v-slot="{ navigate }">
+        <BaseButton variant="primary" @click="navigate">
+          <PlusIcon />
+          <span class="button-text">Nuovo Trade</span>
+        </BaseButton>
+      </router-link>
     </div>
 
     <!-- Stats Grid -->
@@ -142,10 +122,6 @@ watch(
     />
 
     <!-- Modals -->
-    <BaseModal :show="uiStore.isAddTradeModalOpen" @close="uiStore.closeAddTradeModal">
-      <template #header><h3>Log New Trade</h3></template>
-      <NewTradeForm @submit="handleNewTrade" />
-    </BaseModal>
     <DailySummaryModal />
     <WeeklySummaryModal />
   </div>


### PR DESCRIPTION
This commit refactors the user flow for adding a new trade. The previous implementation, which used a modal on the dashboard, has been replaced with a dedicated page at the `/add-trade` route.

The new page presents the user with a choice between adding a trade manually or importing from a broker. The 'Manual' option reveals the existing `NewTradeForm` on the same page. The 'Import' option is a placeholder for future functionality.

Key changes include:
- A new `AddTradeView.vue` component to house the new user flow.
- A new `/add-trade` route in the Vue router.
- Modification of `DashboardView.vue` to remove the modal and update the 'Nuovo Trade' button to a navigation link.
- Cleanup of `uiStore.js` to remove the now-unused state and actions for the modal.
- Styling of the `AddTradeView` to provide a clean and intuitive user experience.