### PR TITLE
feat(dashboard): Improve stats card layout and text handling

### DIFF
--- a/frontend/src/components/dashboard/widgets/StatCard/index.vue
+++ b/frontend/src/components/dashboard/widgets/StatCard/index.vue
@@ -88,15 +88,12 @@ const isWinRate = computed(() => props.stat.key === 'winRate');
   display: flex;
   flex-direction: column;
   gap: var(--semantic-size-stack-xs);
-  /* BEST PRACTICE: No Text Wrapping (come da richiesta)
-     Manteniamo il testo su una sola riga per preservare il layout a 2 colonne.
-     Questo ci costringe a essere molto attenti con le spaziature e le dimensioni
-     dei font su schermi piccoli. */
-  white-space: normal;
+  min-width: 0;
 }
 .stat-label {
   font: var(--semantic-font-style-body-sm);
   color: var(--semantic-color-text-secondary);
+  white-space: nowrap;
 }
 /*
   BEST PRACTICE: Tipografia Fluida
@@ -107,6 +104,7 @@ const isWinRate = computed(() => props.stat.key === 'winRate');
 .stat-value {
   font: var(--semantic-font-style-metric-display);
   color: var(--semantic-color-text-primary);
+  white-space: nowrap;
 }
 .stat-value--positive {
   color: var(--semantic-color-feedback-positive-text);

--- a/frontend/src/components/dashboard/zones/StatsZone.vue
+++ b/frontend/src/components/dashboard/zones/StatsZone.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref, onMounted, onUpdated, watch, nextTick } from 'vue';
 import draggable from 'vuedraggable';
 import { useUiStore } from '../../../stores/uiStore';
 import { useTradesStore } from '../../../stores/trades';
@@ -12,6 +12,35 @@ const uiStore = useUiStore();
 const tradesStore = useTradesStore();
 
 const isEditing = computed(() => uiStore.isLayoutEditing);
+const grid = ref(null);
+
+const adjustFontOnOverflow = async () => {
+    await nextTick();
+
+    const gridEl = grid.value?.$el;
+    if (!gridEl) return;
+
+    // Reset class before checking
+    gridEl.classList.remove('stats-grid--font-sm');
+
+    const labels = gridEl.querySelectorAll('.stat-label');
+    const values = gridEl.querySelectorAll('.stat-value');
+    let isOverflowing = false;
+
+    for (const el of [...labels, ...values]) {
+        if (el.scrollWidth > el.clientWidth) {
+            isOverflowing = true;
+            break;
+        }
+    }
+    if (isOverflowing) {
+        gridEl.classList.add('stats-grid--font-sm');
+    }
+};
+
+onMounted(adjustFontOnOverflow);
+onUpdated(adjustFontOnOverflow);
+watch(() => uiStore.visibleStatKeys, adjustFontOnOverflow, { deep: true });
 
 const onStatsDragEnd = (event) => {
   uiStore.moveStat({
@@ -24,6 +53,7 @@ const onStatsDragEnd = (event) => {
 <template>
   <div class="grid-zone-wrapper">
     <draggable
+      ref="grid"
       :list="uiStore.visibleStatKeys"
       item-key="key"
       tag="div"
@@ -66,6 +96,13 @@ const onStatsDragEnd = (event) => {
   gap: var(--semantic-size-stack-lg);
   min-width: 0; /* Fix for grid inside flexbox overflow */
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+/* --- QUERIES DESKTOP FIRST --- */
+@media (min-width: 1200px) {
+    .stats-grid {
+        grid-template-columns: repeat(5, 1fr);
+    }
 }
 
 @media (max-width: 640px) {
@@ -141,5 +178,12 @@ const onStatsDragEnd = (event) => {
   background-color: var(--semantic-color-surface-secondary);
   color: var(--semantic-color-text-primary);
   border-color: var(--semantic-color-border-focus);
+}
+
+.stats-grid--font-sm .stat-label {
+    font-size: 0.75rem !important;
+}
+.stats-grid--font-sm .stat-value {
+    font-size: 1.5rem !important;
 }
 </style>

--- a/jules-scratch/verification/verify_stats_card_fix.py
+++ b/jules-scratch/verification/verify_stats_card_fix.py
@@ -1,0 +1,42 @@
+import re
+from playwright.sync_api import sync_playwright, Page, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context(
+        viewport={'width': 1920, 'height': 1080} # Set a large viewport for the test
+    )
+    page = context.new_page()
+
+    try:
+        # Navigate to the login page
+        page.goto("http://localhost:5173/login")
+
+        # Fill in the login form
+        page.get_by_label("Email").fill("test@example.com")
+        page.get_by_label("Password").fill("password")
+
+        # Click the login button
+        page.get_by_role("button", name="Login").click()
+
+        # Wait for navigation to the dashboard
+        expect(page).to_have_url(re.compile(r".*/dashboard$"))
+
+        # Wait for the stats grid to be visible
+        stats_grid = page.locator(".stats-grid")
+        expect(stats_grid).to_be_visible()
+
+        # Take a screenshot of the dashboard, focusing on the stats cards
+        stats_grid.screenshot(path="jules-scratch/verification/verification.png")
+
+        print("Screenshot saved to jules-scratch/verification/verification.png")
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        page.screenshot(path="jules-scratch/verification/error.png")
+
+    finally:
+        browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)


### PR DESCRIPTION
This commit addresses issues with the stats card layout on large screens.

- Implements a 5-column grid for stats cards on screens wider than 1200px.
- Prevents card titles and values from wrapping to new lines.
- Adds a dynamic font-size adjustment mechanism: if any card's text overflows, the font size for all cards is reduced uniformly to maintain visual consistency. This is handled via JavaScript in the parent `StatsZone` component.