### PR TITLE
fix(frontend): Resolve stat card responsiveness and CSS warning

### DIFF
--- a/frontend/src/components/dashboard/zones/StatsZone.vue
+++ b/frontend/src/components/dashboard/zones/StatsZone.vue
@@ -61,26 +61,6 @@ const onStatsDragEnd = (event) => {
 </template>
 
 <style scoped>
-.stats-grid {
-  display: grid;
-  gap: var(--semantic-size-stack-lg);
-  min-width: 0; /* Fix for grid inside flexbox overflow */
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-}
-
-@media (max-width: 640px) {
-  .stats-grid {
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  }
-}
-
-@media (max-width: 400px) {
-  .stats-grid {
-    grid-template-columns: 1fr 1fr;
-    gap: var(--semantic-size-stack-sm);
-  }
-}
-
 .ghost {
   opacity: 0.5;
   background-color: var(--semantic-color-surface-secondary);

--- a/frontend/src/views/AddTradeView.vue
+++ b/frontend/src/views/AddTradeView.vue
@@ -208,10 +208,6 @@ const handleNewTrade = async (tradeData) => {
     font-weight: 600;
 }
 
-.form-view {
-    /* Styles removed to integrate the form directly into the page */
-}
-
 .form-header {
     display: flex;
     align-items: center;

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -186,7 +186,8 @@ watch(
 }
 @media (max-width: 640px) {
   .stats-grid {
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    grid-template-columns: 1fr 1fr;
+    gap: var(--semantic-size-stack-md);
   }
 }
 

--- a/frontend/tokens/base/font/fluid-size.json
+++ b/frontend/tokens/base/font/fluid-size.json
@@ -41,9 +41,9 @@
         },
         "stat-display": {
           "$comment": "Dimensione fluida per i valori principali nelle StatCard, ottimizzata per mobile.",
-          "min": { "$value": "1rem", "$type": "dimension" },
-          "ideal": { "$value": "2vw", "$type": "dimension" },
-          "max": { "$value": "1.2rem", "$type": "dimension" }
+          "min": { "$value": "0.8rem", "$type": "dimension" },
+          "ideal": { "$value": "2.5vw", "$type": "dimension" },
+          "max": { "$value": "1.1rem", "$type": "dimension" }
         },
         "fluid-heading-xl": {
           "min": { "$value": "{base.font.size.lg}", "$type": "dimension" },

--- a/frontend/tokens/semantic/size/component.json
+++ b/frontend/tokens/semantic/size/component.json
@@ -35,8 +35,8 @@
           "chart": {
             "width": {
               "desktop": { "$value": "60px", "$type": "dimension" },
-              "tablet": { "$value": "48px", "$type": "dimension" },
-              "mobile": { "$value": "40px", "$type": "dimension" }
+              "tablet": { "$value": "44px", "$type": "dimension" },
+              "mobile": { "$value": "36px", "$type": "dimension" }
             }
           }
         },


### PR DESCRIPTION
This commit addresses two issues:
1.  An empty CSS ruleset for `.form-view` in `AddTradeView.vue` has been removed, fixing a linting warning.
2.  The responsiveness of the dashboard's `StatCard` components has been fixed to prevent content overflow and improve layout fluidity.

The stats grid layout has been consolidated into `DashboardView.vue` to act as a single source of truth, enforcing a two-column layout on mobile screens as requested.

To support this, the `StatCard`'s internal content has been made more compact by adjusting the semantic design tokens for fluid font sizes and component chart widths. This ensures the cards fit correctly within the new responsive grid without their content overflowing.