### PR TITLE
feat: Replace sidebar navigation icons with Lucide icons

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@vueuse/core": "^13.9.0",
         "axios": "^1.11.0",
         "chart.js": "^4.5.0",
+        "lucide-vue-next": "^0.544.0",
         "pinia": "^3.0.3",
         "vue": "^3.5.18",
         "vue-chartjs": "^5.3.2",
@@ -4546,6 +4547,15 @@
       "license": "ISC",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/lucide-vue-next": {
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-0.544.0.tgz",
+      "integrity": "sha512-mDp/AdGOPIDkpFHnFiTWgQgCST9aBXHVaiobZfOMIvv7nrOukzF/TP+7KoOwrngdWRaH9TMiepMBIX1vsgKJ3g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
       }
     },
     "node_modules/magic-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@vueuse/core": "^13.9.0",
     "axios": "^1.11.0",
     "chart.js": "^4.5.0",
+    "lucide-vue-next": "^0.544.0",
     "pinia": "^3.0.3",
     "vue": "^3.5.18",
     "vue-chartjs": "^5.3.2",

--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -14,6 +14,12 @@ import { useAuthStore } from '../../stores/auth';
 import ThemeToggle from '../ui/ThemeToggle.vue';
 import MfaModal from '../mfa/MfaModal.vue'; // Importa la nuova modale
 import { computed, ref } from 'vue';
+import {
+  LayoutDashboard,
+  ArrowRightLeft,
+  BarChart2,
+  Settings,
+} from 'lucide-vue-next';
 
 // --- STORE ---
 const uiStore = useUiStore();
@@ -35,10 +41,10 @@ function openMfaModal(mode) {
 // Dati per i link di navigazione.
 // Usare un array rende più facile gestire l'aggiunta di icone in futuro.
 const navLinks = [
-  { to: '/', text: 'Dashboard', icon: 'D' },
-  { to: '/trades', text: 'Trades', icon: 'T' },
-  { to: '/analytics', text: 'Analytics', icon: 'A' },
-  { to: '#', text: 'Settings', icon: 'S' },
+  { to: '/', text: 'Dashboard', icon: LayoutDashboard },
+  { to: '/trades', text: 'Trades', icon: ArrowRightLeft },
+  { to: '/analytics', text: 'Analytics', icon: BarChart2 },
+  { to: '#', text: 'Settings', icon: Settings },
 ];
 </script>
 
@@ -69,7 +75,7 @@ const navLinks = [
         class="nav-item"
         @click="uiStore.closeMobileMenu"
       >
-        <span class="nav-icon">{{ link.icon }}</span>
+        <component :is="link.icon" class="nav-icon" />
         <span v-if="!uiStore.isSidebarCollapsed" class="nav-text">{{ link.text }}</span>
       </RouterLink>
     </nav>
@@ -203,7 +209,6 @@ const navLinks = [
   justify-content: center;
 }
 .nav-icon {
-  font-weight: bold;
   min-width: 20px;
   text-align: center;
 }


### PR DESCRIPTION
Replaces the simple letter-based navigation icons in the sidebar with more descriptive and visually appealing SVG icons from the lucide-vue-next library.

This change improves the user interface by providing clearer visual cues for navigation items.

The following icons were used:
- Dashboard: LayoutDashboard
- Trades: ArrowRightLeft
- Analytics: BarChart2
- Settings: Settings