### PR TITLE
fix(frontend): Align dashboard stats getter with backend API

### DIFF
--- a/frontend/src/stores/trades.js
+++ b/frontend/src/stores/trades.js
@@ -83,11 +83,11 @@ export const useTradesStore = defineStore('trades', {
       }
 
       const stats = this.dashboardStats.stats;
-      const totalPnl = parseFloat(stats.total_pl);
+      const totalPnl = parseFloat(stats.net_pnl); // Corretto da total_pl
       const tradeCount = stats.trade_count;
-      const winningTrades = stats.winning_trades_count;
-      const losingTrades = stats.losing_trades_count;
-      const breakEvenTrades = stats.breakeven_trades_count;
+      const winningTrades = stats.winning_trades; // Corretto da winning_trades_count
+      const losingTrades = stats.losing_trades; // Corretto da losing_trades_count
+      const breakEvenTrades = stats.breakeven_trades; // Corretto da breakeven_trades_count
       const winRate = parseFloat(stats.win_rate);
       const avgWin = parseFloat(stats.avg_win);
       const avgLoss = parseFloat(stats.avg_loss);


### PR DESCRIPTION
This commit resolves the issue where the main dashboard widgets (StatsCard) were not displaying data correctly.

The problem was a naming mismatch in the `allDashboardStats` getter within the `trades.js` store. The getter was still referencing old field names (e.g., `total_pl`, `winning_trades_count`) after the backend API had been updated to use more consistent names (e.g., `net_pnl`, `winning_trades`).

This change updates the getter to use the correct field names, ensuring that the frontend correctly parses the data from the `/api/v1/trades/performance/metrics` endpoint and displays it in the dashboard widgets.