### PR TITLE
Aggiorna lo schema di `trading_account` alla sintassi di Pydantic V2.

### DIFF
--- a/backend/app/Schemas/trading_account.py
+++ b/backend/app/Schemas/trading_account.py
@@ -1,13 +1,12 @@
-# app/Schemas/trading_account.py
 from __future__ import annotations
 from uuid import UUID
 from datetime import datetime
 from typing import Optional
 from pydantic import BaseModel, Field
+from decimal import Decimal
 
 from .broker import BrokerRead
 
-from pydantic import condecimal
 
 class TradingAccountRead(BaseModel):
     id: UUID
@@ -15,18 +14,18 @@ class TradingAccountRead(BaseModel):
     broker_id: Optional[UUID] = None
     label: Optional[str] = None
     created_at: datetime
-    initial_balance: Optional[condecimal(max_digits=10, decimal_places=2)] = None
+    initial_balance: Optional[Decimal] = Field(None, max_digits=10, decimal_places=2)
     currency: Optional[str] = None
     broker_name: Optional[str] = Field(None, alias='broker_name')
     broker: Optional[BrokerRead] = None
 
     class Config:
         from_attributes = True
-        allow_population_by_field_name = True
+        populate_by_name = True
 
 
 class TradingAccountCreate(BaseModel):
     label: str
     broker_id: UUID
-    initial_balance: condecimal(max_digits=10, decimal_places=2)
+    initial_balance: Decimal = Field(..., max_digits=10, decimal_places=2)
     currency: str


### PR DESCRIPTION
Questo commit risolve i seguenti problemi:
- Sostituisce `condecimal`, che è deprecato, con `Decimal` e `Field` per la validazione.
- Aggiorna la chiave di configurazione `allow_population_by_field_name` a `populate_by_name` per allinearla a Pydantic V2.

Queste modifiche eliminano gli avvisi e gli errori di Pylance, garantendo la compatibilità con la versione più recente di Pydantic.