### PR TITLE
feat: Refactor metrics, fix UI bugs and modal data loading

### DIFF
--- a/backend/app/Controllers/trades_controller.py
+++ b/backend/app/Controllers/trades_controller.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import List, Optional
 from uuid import UUID
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Query
 
 from app.Services.trade_service import TradeService
 from app.Services.analytics_service import AnalyticsService
@@ -33,9 +33,10 @@ async def get_performance_metrics(
     trading_account_id: UUID,
     start_date: date,
     end_date: date,
+    setups: Optional[List[str]] = Query(None),
     service: AnalyticsService = Depends(),
 ):
-    return await service.get_performance_metrics(trading_account_id, start_date, end_date)
+    return await service.get_performance_metrics(trading_account_id, start_date, end_date, setups)
 
 @router.get("/calendar/data/{trading_account_id}", response_model=List[CalendarDayData])
 async def get_calendar_data(
@@ -43,45 +44,50 @@ async def get_calendar_data(
     start_date: date,
     end_date: date,
     user_timezone: str,
+    setups: Optional[List[str]] = Query(None),
     service: AnalyticsService = Depends(),
 ):
-    return await service.get_calendar_data(trading_account_id, start_date, end_date, user_timezone)
+    return await service.get_calendar_data(trading_account_id, start_date, end_date, user_timezone, setups)
 
 @router.get("/processed-stats/{trading_account_id}", response_model=ProcessedStats)
 async def get_processed_stats(
     trading_account_id: UUID,
     start_date: date,
     end_date: date,
+    setups: Optional[List[str]] = Query(None),
     service: AnalyticsService = Depends(),
 ):
-    return await service.get_processed_stats(trading_account_id, start_date, end_date)
+    return await service.get_processed_stats(trading_account_id, start_date, end_date, setups)
 
 @router.get("/vantage-score/{trading_account_id}", response_model=VantageScoreData)
 async def get_vantage_score(
     trading_account_id: UUID,
     start_date: date,
     end_date: date,
+    setups: Optional[List[str]] = Query(None),
     service: AnalyticsService = Depends(),
 ):
-    return await service.get_vantage_score(trading_account_id, start_date, end_date)
+    return await service.get_vantage_score(trading_account_id, start_date, end_date, setups)
 
 @router.get("/equity-curve/{trading_account_id}", response_model=EquityCurveData)
 async def get_equity_curve(
     trading_account_id: UUID,
     start_date: date,
     end_date: date,
+    setups: Optional[List[str]] = Query(None),
     service: AnalyticsService = Depends(),
 ):
-    return await service.get_equity_curve(trading_account_id, start_date, end_date)
+    return await service.get_equity_curve(trading_account_id, start_date, end_date, setups)
 
 @router.get("/summary/{trading_account_id}", response_model=TradeSummary)
 async def get_trade_summary(
     trading_account_id: UUID,
     start_date: date,
     end_date: date,
+    setups: Optional[List[str]] = Query(None),
     service: AnalyticsService = Depends(),
 ):
-    return await service.get_trade_summary(trading_account_id, start_date, end_date)
+    return await service.get_trade_summary(trading_account_id, start_date, end_date, setups)
 
 
 @router.post("/", response_model=TradeRead, status_code=status.HTTP_201_CREATED)

--- a/backend/app/Repositories/trade_repository.py
+++ b/backend/app/Repositories/trade_repository.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.Models.trade import Trade
+from app.Models.playbook import Playbook
 from app.Schemas.trade import TradeCreate, TradeUpdate
 
 
@@ -53,9 +54,10 @@ class TradeRepository:
         self,
         trading_account_id: UUID,
         start_date: date,
-        end_date: date
+        end_date: date,
+        setups: Optional[List[str]] = None,
     ) -> List[Trade]:
-        """Recupera i trade filtrati per un intervallo di date, includendo l'intero giorno di fine."""
+        """Recupera i trade filtrati per un intervallo di date e, opzionalmente, per playbook."""
         from datetime import datetime, time
 
         start_datetime = datetime.combine(start_date, time.min)
@@ -64,8 +66,12 @@ class TradeRepository:
         query = self._get_trade_query().where(
             Trade.trading_account_id == trading_account_id,
             Trade.entry_timestamp >= start_datetime,
-            Trade.entry_timestamp <= end_datetime
+            Trade.entry_timestamp <= end_datetime,
         )
+
+        if setups:
+            query = query.join(Trade.playbooks).where(Playbook.title.in_(setups))
+
         result = await self.db.execute(query)
         return result.unique().scalars().all()
 

--- a/backend/app/Services/analytics_service.py
+++ b/backend/app/Services/analytics_service.py
@@ -32,9 +32,9 @@ class AnalyticsService:
         self.trade_repo = TradeRepository(db)
         self.trading_account_repo = TradingAccountRepository(db)
 
-    async def _get_calculator(self, trading_account_id: UUID, start_date: date, end_date: date) -> MetricsCalculator:
+    async def _get_calculator(self, trading_account_id: UUID, start_date: date, end_date: date, setups: Optional[List[str]] = None) -> MetricsCalculator:
         """Helper method to get trades and instantiate the calculator."""
-        trades = await self.trade_repo.get_filtered_trades(trading_account_id, start_date, end_date)
+        trades = await self.trade_repo.get_filtered_trades(trading_account_id, start_date, end_date, setups)
         trading_account = await self.trading_account_repo.get_by_id(trading_account_id)
 
         initial_balance = trading_account.initial_balance if trading_account else 0.0
@@ -42,12 +42,12 @@ class AnalyticsService:
         return MetricsCalculator(trades, initial_balance)
 
     async def get_performance_metrics(
-        self, trading_account_id: UUID, start_date: date, end_date: date
+        self, trading_account_id: UUID, start_date: date, end_date: date, setups: Optional[List[str]] = None
     ) -> PerformanceMetrics:
         """
         Calculates and returns main performance metrics.
         """
-        calculator = await self._get_calculator(trading_account_id, start_date, end_date)
+        calculator = await self._get_calculator(trading_account_id, start_date, end_date, setups)
         all_metrics = calculator.get_all_metrics()
 
         # Map calculator results to the PerformanceStats Pydantic schema
@@ -80,23 +80,23 @@ class AnalyticsService:
         return PerformanceMetrics(stats=stats)
 
     async def get_calendar_data(
-        self, trading_account_id: UUID, start_date: date, end_date: date, user_timezone: str
+        self, trading_account_id: UUID, start_date: date, end_date: date, user_timezone: str, setups: Optional[List[str]] = None
     ) -> List[CalendarDayData]:
         """
         Returns data aggregated by day for the calendar view.
         """
-        calculator = await self._get_calculator(trading_account_id, start_date, end_date)
+        calculator = await self._get_calculator(trading_account_id, start_date, end_date, setups)
         calendar_data = calculator.calculate_calendar_data()
 
         return [CalendarDayData(**item) for item in calendar_data]
 
     async def get_processed_stats(
-        self, trading_account_id: UUID, start_date: date, end_date: date
+        self, trading_account_id: UUID, start_date: date, end_date: date, setups: Optional[List[str]] = None
     ) -> ProcessedStats:
         """
         Returns aggregated stats like 'by_strategy', 'by_day_of_week', etc.
         """
-        calculator = await self._get_calculator(trading_account_id, start_date, end_date)
+        calculator = await self._get_calculator(trading_account_id, start_date, end_date, setups)
         processed_data = calculator.calculate_processed_stats()
 
         # Map the nested dictionary to the required Pydantic models
@@ -113,13 +113,13 @@ class AnalyticsService:
         )
 
     async def get_vantage_score(
-        self, trading_account_id: UUID, start_date: date, end_date: date
+        self, trading_account_id: UUID, start_date: date, end_date: date, setups: Optional[List[str]] = None
     ) -> VantageScoreData:
         """
         Calculates and returns the Vantage Score and its components.
         This logic remains here as it's a specific interpretation of the base metrics.
         """
-        calculator = await self._get_calculator(trading_account_id, start_date, end_date)
+        calculator = await self._get_calculator(trading_account_id, start_date, end_date, setups)
         metrics = calculator.get_all_metrics()
 
         if metrics["trade_count"] < 5:
@@ -160,24 +160,24 @@ class AnalyticsService:
         )
 
     async def get_equity_curve(
-        self, trading_account_id: UUID, start_date: date, end_date: date
+        self, trading_account_id: UUID, start_date: date, end_date: date, setups: Optional[List[str]] = None
     ) -> EquityCurveData:
         """
         Returns data for the equity curve chart.
         """
-        calculator = await self._get_calculator(trading_account_id, start_date, end_date)
+        calculator = await self._get_calculator(trading_account_id, start_date, end_date, setups)
         equity_curve_data = calculator.calculate_equity_curve()
         return EquityCurveData(**equity_curve_data)
 
     async def get_trade_summary(
-        self, trading_account_id: UUID, start_date: date, end_date: date
+        self, trading_account_id: UUID, start_date: date, end_date: date, setups: Optional[List[str]] = None
     ) -> TradeSummary:
         """
         Returns a complete summary of trades for a given period.
         """
         # We can call the other methods in this service to build the summary
-        performance_metrics = await self.get_performance_metrics(trading_account_id, start_date, end_date)
-        equity_curve = await self.get_equity_curve(trading_account_id, start_date, end_date)
+        performance_metrics = await self.get_performance_metrics(trading_account_id, start_date, end_date, setups)
+        equity_curve = await self.get_equity_curve(trading_account_id, start_date, end_date, setups)
 
         return TradeSummary(
             stats=performance_metrics.stats,


### PR DESCRIPTION
This commit completely overhauls the performance metrics calculation system to base all key metrics on the trading account's `initial_balance`. This provides a more accurate and professional representation of performance.

This commit also addresses several frontend and backend bugs that appeared after the initial refactoring.

Key changes:

- **Backend Refactoring:**
  - Introduced a new `MetricsCalculator` class in `app/Services/metrics/` to centralize all calculation logic.
  - The `calculate_equity_curve` method now returns a data point for every trade, making it more granular and ensuring charts can always be rendered.
  - All analytics API endpoints in `trades_controller.py` were updated to use a consistent, RESTful design and to correctly handle optional strategy filters.

- **Frontend Updates & Bug Fixes:**
  - The `trades.js` Pinia store was updated to handle the new metrics and call the standardized backend routes.
  - **FIX**: Corrected a 404 error by updating the playbook fetch URL to `/me/playbooks`.
  - **FIX**: Resolved UI rendering errors by making the `allDashboardStats` getter robust against undefined data.
  - **FIX**: Corrected a `TypeError` on `initialBalance.toFixed` by ensuring the value is parsed as a number with `parseFloat()`.
  - **FIX**: Corrected a 422 error in summary modals by updating `fetchTradeSummary` to use the correct RESTful URL.
  - **FIX**: Ensured charts and stats in daily/weekly summary modals now render and calculate correctly by applying the strategy filter in the backend.