### PR TITLE
feat: Create Playbooks page with stats and dynamic layout

### DIFF
--- a/backend/app/Controllers/playbook_controller.py
+++ b/backend/app/Controllers/playbook_controller.py
@@ -9,8 +9,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.Infrastructure.db import get_db
 from app.Repositories.playbook_repository import PlaybookRepository
-from app.Schemas.playbook import PlaybookCreate, PlaybookRead, PlaybookUpdate, PlaybookAdminRead
+from app.Schemas.playbook import PlaybookCreate, PlaybookRead, PlaybookUpdate, PlaybookAdminRead, PlaybookStats
 from app.Router.dependencies import get_current_user, get_current_general_account_id, CurrentUser
+from app.Services.metrics.metrics_calculator import MetricsCalculator
 
 
 class PlaybookController:
@@ -45,11 +46,25 @@ class PlaybookController:
         db: AsyncSession = Depends(get_db),
     ) -> List[PlaybookRead]:
         """
-        Lista tutti i playbook dell'utente autenticato.
+        Lista tutti i playbook dell'utente autenticato, arricchiti con le statistiche.
         """
         repo = PlaybookRepository(db)
-        playbooks = await repo.list_by_general_account_id(general_account_id)
-        return [PlaybookRead.from_orm(p) for p in playbooks]
+        playbooks = await repo.list_by_general_account_id_with_trades(general_account_id)
+
+        response_playbooks = []
+        for playbook in playbooks:
+            # Calcola le statistiche per ogni playbook
+            # L'initial_balance non è rilevante per le metriche del playbook, quindi passiamo 0.0
+            calculator = MetricsCalculator(trades=playbook.trades, initial_balance=0.0)
+            stats_data = calculator.get_playbook_summary_metrics()
+
+            # Crea lo schema di risposta e popola le statistiche
+            playbook_read = PlaybookRead.from_orm(playbook)
+            playbook_read.stats = PlaybookStats(**stats_data)
+
+            response_playbooks.append(playbook_read)
+
+        return response_playbooks
 
     async def get_playbook(
         self,

--- a/backend/app/Repositories/playbook_repository.py
+++ b/backend/app/Repositories/playbook_repository.py
@@ -37,6 +37,19 @@ class PlaybookRepository:
         res = await self.db.execute(stmt)
         return res.scalars().all()
 
+    async def list_by_general_account_id_with_trades(self, general_account_id: UUID) -> Sequence[Playbook]:
+        stmt = (
+            select(Playbook)
+            .where(Playbook.general_account_id == general_account_id)
+            .options(
+                selectinload(Playbook.rules_groups),
+                selectinload(Playbook.trades)  # Eager load trades
+            )
+            .order_by(Playbook.title.asc())
+        )
+        res = await self.db.execute(stmt)
+        return res.scalars().all()
+
     async def create(self, playbook_in: PlaybookCreate, general_account_id: UUID) -> Playbook:
         db_playbook = Playbook(
             **playbook_in.model_dump(),

--- a/backend/app/Schemas/playbook.py
+++ b/backend/app/Schemas/playbook.py
@@ -30,6 +30,16 @@ class PlaybookCreate(PlaybookBase):
 class PlaybookUpdate(PlaybookBase):
     pass # title, description e private sono già opzionali in PlaybookBase
 
+# Schema per le statistiche calcolate di un playbook
+class PlaybookStats(BaseModel):
+    total_trades: int = 0
+    win_rate: float = 0.0
+    profit_factor: Optional[float] = None
+    expectancy: float = 0.0
+    avg_winner: float = 0.0
+    avg_loser: float = 0.0
+    net_pnl: float = 0.0
+
 # Schema per la lettura di un playbook (usato nelle risposte GET)
 class PlaybookRead(PlaybookBase):
     id: UUID
@@ -38,6 +48,7 @@ class PlaybookRead(PlaybookBase):
     description: str
     private: bool
     rules_groups: List["RulesGroupRead"] = []
+    stats: Optional[PlaybookStats] = None
 
 
 class PlaybookAdminRead(BaseModel):

--- a/backend/app/Services/metrics/metrics_calculator.py
+++ b/backend/app/Services/metrics/metrics_calculator.py
@@ -100,6 +100,40 @@ class MetricsCalculator:
         }
         return metrics
 
+    def get_playbook_summary_metrics(self) -> Dict[str, Any]:
+        """
+        Calculates a summarized set of metrics, typically for a playbook.
+        This is ideal for getting quick stats without all the details.
+        """
+        if self.trade_count == 0:
+            return {
+                "total_trades": 0,
+                "win_rate": 0.0,
+                "profit_factor": None,
+                "expectancy": 0.0,
+                "avg_winner": 0.0,
+                "avg_loser": 0.0,
+                "net_pnl": 0.0,
+            }
+
+        win_rate = (self.winning_trades_count / self.trade_count) * 100
+        avg_winner = self.gross_profit / self.winning_trades_count if self.winning_trades_count > 0 else 0
+        avg_loser = self.gross_loss / self.losing_trades_count if self.losing_trades_count > 0 else 0
+
+        expectancy = self._calculate_expectancy(win_rate, avg_winner, avg_loser)
+
+        profit_factor = self.gross_profit / self.gross_loss if self.gross_loss > 0 else None
+
+        return {
+            "total_trades": self.trade_count,
+            "win_rate": win_rate,
+            "profit_factor": profit_factor,
+            "expectancy": expectancy,
+            "avg_winner": avg_winner,
+            "avg_loser": avg_loser,
+            "net_pnl": self.net_pnl,
+        }
+
     def _get_default_metrics(self) -> Dict[str, Any]:
         """Returns a dictionary with default values for when there are no trades."""
         default_processed = {

--- a/frontend/src/components/Playbooks/DoughnutChart.vue
+++ b/frontend/src/components/Playbooks/DoughnutChart.vue
@@ -1,0 +1,69 @@
+<template>
+  <svg :viewBox="`0 0 ${size} ${size}`" class="doughnut-chart">
+    <circle
+      class="doughnut-chart-bg"
+      :cx="center"
+      :cy="center"
+      :r="radius"
+      :stroke-width="strokeWidth"
+    />
+    <circle
+      class="doughnut-chart-fg"
+      :cx="center"
+      :cy="center"
+      :r="radius"
+      :stroke-width="strokeWidth"
+      :stroke-dasharray="circumference"
+      :stroke-dashoffset="dashOffset"
+      :transform="`rotate(-90 ${center} ${center})`"
+    />
+  </svg>
+</template>
+
+<script setup>
+import { computed, defineProps } from 'vue';
+
+const props = defineProps({
+  percentage: {
+    type: Number,
+    required: true,
+    validator: (value) => value >= 0 && value <= 100,
+  },
+  size: {
+    type: Number,
+    default: 40,
+  },
+  strokeWidth: {
+    type: Number,
+    default: 4,
+  },
+});
+
+const center = computed(() => props.size / 2);
+const radius = computed(() => center.value - props.strokeWidth / 2);
+const circumference = computed(() => 2 * Math.PI * radius.value);
+
+const dashOffset = computed(() => {
+  const progress = props.percentage / 100;
+  return circumference.value * (1 - progress);
+});
+</script>
+
+<style scoped>
+.doughnut-chart {
+  width: 100%;
+  height: 100%;
+}
+
+.doughnut-chart-bg {
+  fill: none;
+  stroke: var(--semantic-color-surface-secondary);
+}
+
+.doughnut-chart-fg {
+  fill: none;
+  stroke: var(--semantic-color-interactive-primary-default);
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.3s ease-in-out;
+}
+</style>

--- a/frontend/src/components/Playbooks/PlaybookCard.vue
+++ b/frontend/src/components/Playbooks/PlaybookCard.vue
@@ -1,0 +1,150 @@
+<template>
+  <router-link :to="{ name: 'playbook-detail', params: { id: playbook.id } }" class="playbook-card-link">
+    <BaseWidget>
+      <template #header>
+        <div class="card-header">
+          <h3 class="widget-title">{{ playbook.title }}</h3>
+          <span class="trade-count">{{ playbook.stats.total_trades }} Trades</span>
+        </div>
+      </template>
+
+      <div class="stats-grid">
+        <div class="stat-item win-rate-stat">
+          <div class="donut-chart-container">
+            <DoughnutChart :percentage="playbook.stats.win_rate" />
+          </div>
+          <div class="stat-value-label">
+            <span class="value">{{ playbook.stats.win_rate.toFixed(1) }}%</span>
+            <span class="label">Win Rate</span>
+          </div>
+        </div>
+
+        <div class="stat-item">
+          <span class="value">{{ formatCurrency(playbook.stats.net_pnl) }}</span>
+          <span class="label">Net PnL</span>
+        </div>
+
+        <div class="stat-item">
+          <span class="value">{{ playbook.stats.profit_factor ? playbook.stats.profit_factor.toFixed(2) : '∞' }}</span>
+          <span class="label">Profit Factor</span>
+        </div>
+
+        <div class="stat-item">
+          <span class="value">{{ formatCurrency(playbook.stats.expectancy) }}</span>
+          <span class="label">Expectancy</span>
+        </div>
+
+        <div class="stat-item">
+          <span class="value">{{ formatCurrency(playbook.stats.avg_winner) }}</span>
+          <span class="label">Avg. Winner</span>
+        </div>
+
+        <div class="stat-item">
+          <span class="value">{{ formatCurrency(playbook.stats.avg_loser) }}</span>
+          <span class="label">Avg. Loser</span>
+        </div>
+      </div>
+    </BaseWidget>
+  </router-link>
+</template>
+
+<script setup>
+import { defineProps } from 'vue';
+import BaseWidget from '../layout/BaseWidget.vue';
+import DoughnutChart from './DoughnutChart.vue';
+
+const props = defineProps({
+  playbook: {
+    type: Object,
+    required: true,
+  },
+});
+
+function formatCurrency(value) {
+  if (typeof value !== 'number') {
+    return '$0.00';
+  }
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(value);
+}
+</script>
+
+<style scoped>
+.playbook-card-link {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+.playbook-card-link:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--semantic-shadow-lg);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.widget-title {
+  font: var(--semantic-font-style-heading-md);
+  color: var(--semantic-color-text-primary);
+}
+
+.trade-count {
+  font: var(--semantic-font-style-body-sm);
+  color: var(--semantic-color-text-secondary);
+  background-color: var(--semantic-color-surface-secondary);
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--semantic-border-radius-pill);
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem 1rem;
+  padding-top: 1rem;
+}
+
+.stat-item {
+  display: flex;
+  flex-direction: column;
+}
+
+.win-rate-stat {
+  grid-column: span 1;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.donut-chart-container {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: var(--semantic-color-surface-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.stat-value-label {
+    display: flex;
+    flex-direction: column;
+}
+
+.stat-item .value {
+  font: var(--semantic-font-style-heading-sm);
+  color: var(--semantic-color-text-primary);
+}
+
+.stat-item .label {
+  font: var(--semantic-font-style-body-xs);
+  color: var(--semantic-color-text-secondary);
+}
+</style>

--- a/frontend/src/components/Playbooks/PlaybookControls.vue
+++ b/frontend/src/components/Playbooks/PlaybookControls.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="playbook-controls">
+    <div class="left-controls">
+      <!-- Search bar can be added here later if needed -->
+    </div>
+    <div class="right-controls">
+      <div class="layout-switchers">
+        <button @click="setLayout('grid')" :class="{ active: currentLayout === 'grid' }">Grid</button>
+        <button @click="setLayout('list')" :class="{ active: currentLayout === 'list' }">List</button>
+      </div>
+      <button class="create-button">Create New Playbook</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, defineEmits } from 'vue';
+
+const emit = defineEmits(['update:layout']);
+
+const currentLayout = ref('grid');
+
+function setLayout(layout) {
+  currentLayout.value = layout;
+  emit('update:layout', layout);
+}
+</script>
+
+<style scoped>
+.playbook-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0;
+}
+
+.right-controls {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.layout-switchers {
+  display: flex;
+  border: 1px solid #ccc;
+  border-radius: var(--semantic-border-radius-interactive);
+  overflow: hidden;
+}
+
+.layout-switchers button {
+  padding: 0.5rem 1rem;
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+}
+
+.layout-switchers button.active {
+  background-color: #e0e0e0;
+}
+
+.create-button {
+  padding: 0.5rem 1rem;
+  background-color: var(--color-primary);
+  color: white;
+  border: none;
+  border-radius: var(--semantic-border-radius-interactive);
+  cursor: pointer;
+}
+
+/* Responsive behavior */
+@media (max-width: 1024px) {
+  .layout-switchers {
+    display: none;
+  }
+}
+</style>

--- a/frontend/src/components/Playbooks/PlaybookList.vue
+++ b/frontend/src/components/Playbooks/PlaybookList.vue
@@ -1,0 +1,72 @@
+<template>
+  <div v-if="isLoading" class="loading-state">
+    <p>Loading playbooks...</p>
+  </div>
+  <div v-else-if="playbooks.length === 0" class="empty-state">
+    <p>No playbooks found. Start by creating one!</p>
+  </div>
+  <div v-else :class="['playbook-list', layoutClass]">
+    <PlaybookCard
+      v-for="playbook in playbooks"
+      :key="playbook.id"
+      :playbook="playbook"
+    />
+  </div>
+</template>
+
+<script setup>
+import { computed, defineProps } from 'vue';
+import PlaybookCard from './PlaybookCard.vue';
+
+const props = defineProps({
+  playbooks: {
+    type: Array,
+    required: true,
+  },
+  layout: {
+    type: String,
+    default: 'grid', // 'grid' or 'list'
+  },
+  isLoading: {
+    type: Boolean,
+    default: false,
+  }
+});
+
+const layoutClass = computed(() => {
+  return props.layout === 'grid' ? 'layout-grid' : 'layout-list';
+});
+</script>
+
+<style scoped>
+.loading-state, .empty-state {
+  text-align: center;
+  padding: 4rem;
+  color: var(--color-text-secondary);
+}
+
+.playbook-list {
+  display: grid;
+  gap: 1rem;
+}
+
+/* Grid layout for desktop */
+.layout-grid {
+  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+  /* As per user request, max 2 columns */
+  grid-template-columns: repeat(2, 1fr);
+}
+
+/* List layout for desktop */
+.layout-list {
+  grid-template-columns: 1fr;
+}
+
+/* Responsive behavior for mobile */
+@media (max-width: 1024px) {
+  .layout-grid, .layout-list {
+    /* Always force single column on mobile */
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -43,6 +43,18 @@ const router = createRouter({
       meta: { title: 'Trades' },
     },
     {
+      path: '/playbooks',
+      name: 'playbooks',
+      component: () => import('../views/PlaybooksView.vue'),
+      meta: { title: 'Playbooks' },
+    },
+    {
+      path: '/playbooks/:id',
+      name: 'playbook-detail',
+      component: () => import('../views/PlaybookDetailView.vue'),
+      meta: { title: 'Playbook Detail' },
+    },
+    {
       path: '/analytics',
       name: 'analytics',
       component: () => import('../views/AnalyticsView.vue'),

--- a/frontend/src/stores/playbookStore.js
+++ b/frontend/src/stores/playbookStore.js
@@ -1,0 +1,50 @@
+import { defineStore } from 'pinia';
+import apiClient from '../services/api';
+import { useAuthStore } from './auth';
+
+export const usePlaybookStore = defineStore('playbooks', {
+  state: () => ({
+    playbooks: [],
+    isLoading: false,
+    error: null,
+  }),
+
+  getters: {
+    /**
+     * Returns all playbooks, useful for selectors or lists.
+     * @param {object} state - The current state.
+     * @returns {Array} The list of playbooks.
+     */
+    allPlaybooks(state) {
+      return state.playbooks;
+    },
+  },
+
+  actions: {
+    /**
+     * Fetches the user's playbooks from the backend, including calculated stats.
+     */
+    async fetchPlaybooks() {
+      const authStore = useAuthStore();
+      if (!authStore.isAuthenticated) {
+        console.log("User not authenticated. Skipping playbook fetch.");
+        return;
+      }
+
+      this.isLoading = true;
+      this.error = null;
+      try {
+        const response = await apiClient.get('/me/playbooks');
+        // The backend now returns playbooks with a 'stats' object.
+        // No special mapping is needed if the frontend can use the structure directly.
+        this.playbooks = response.data;
+      } catch (err) {
+        console.error('Error fetching playbooks:', err);
+        this.error = err.response?.data?.detail || 'An unexpected error occurred.';
+        this.playbooks = []; // Reset on error
+      } finally {
+        this.isLoading = false;
+      }
+    },
+  },
+});

--- a/frontend/src/views/PlaybookDetailView.vue
+++ b/frontend/src/views/PlaybookDetailView.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="playbook-detail-view">
+    <h1>Playbook Detail Page</h1>
+    <p>Details for Playbook with ID: <strong>{{ playbookId }}</strong></p>
+    <div class="placeholder-content">
+      <p>This page is under construction.</p>
+      <p>Full editing and rule management features for this playbook will be available here soon.</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
+
+const route = useRoute();
+const playbookId = ref(null);
+
+onMounted(() => {
+  playbookId.value = route.params.id;
+});
+</script>
+
+<style scoped>
+.playbook-detail-view {
+  padding: 2rem;
+  color: var(--semantic-color-text-primary);
+}
+
+h1 {
+  font: var(--semantic-font-style-heading-xl);
+  margin-bottom: 1rem;
+}
+
+p {
+  font: var(--semantic-font-style-body-lg);
+  margin-bottom: 2rem;
+}
+
+.placeholder-content {
+  border: 1px dashed var(--semantic-color-border-default);
+  border-radius: var(--semantic-border-radius-container);
+  padding: 2rem;
+  text-align: center;
+  background-color: var(--semantic-color-surface-secondary);
+}
+
+.placeholder-content p {
+  margin: 0.5rem 0;
+  color: var(--semantic-color-text-secondary);
+}
+</style>

--- a/frontend/src/views/PlaybooksView.vue
+++ b/frontend/src/views/PlaybooksView.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="playbooks-view">
+    <PlaybookControls @update:layout="updateLayout" />
+    <PlaybookList :playbooks="playbookStore.allPlaybooks" :layout="layout" :is-loading="playbookStore.isLoading" />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import { usePlaybookStore } from '@/stores/playbookStore';
+import PlaybookControls from '@/components/Playbooks/PlaybookControls.vue';
+import PlaybookList from '@/components/Playbooks/PlaybookList.vue';
+
+const playbookStore = usePlaybookStore();
+
+// Layout state, 'grid' is the default
+const layout = ref('grid');
+
+function updateLayout(newLayout) {
+  layout.value = newLayout;
+}
+
+// Fetch playbooks when the component is mounted
+onMounted(() => {
+  playbookStore.fetchPlaybooks();
+});
+</script>
+
+<style scoped>
+.playbooks-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem; /* Spacing between controls and list */
+}
+</style>


### PR DESCRIPTION
This commit introduces the new "Playbooks" page, a full-stack feature that allows users to view their trading playbooks along with key performance statistics.

**Backend Changes:**
- The `/api/v1/me/playbooks` endpoint has been enhanced to include a `stats` object for each playbook.
- A new method, `get_playbook_summary_metrics`, was added to the `MetricsCalculator` to compute essential stats like win rate, profit factor, net PnL, expectancy, and average win/loss.
- The `PlaybookRepository` now eagerly loads associated trades using `selectinload` to prevent N+1 query issues, ensuring efficient data retrieval.
- New Pydantic schemas (`PlaybookStats`) were created to structure the API response.

**Frontend Changes:**
- A new Pinia store, `playbookStore.js`, has been created to manage state for the playbooks feature.
- New routes, `/playbooks` and `/playbooks/:id`, have been added to the Vue Router.
- The UI is built with a 4-component architecture as requested:
  - `PlaybooksView.vue`: The main container view.
  - `PlaybookControls.vue`: Provides layout switching (grid/list) and a "Create" button.
  - `PlaybookList.vue`: Displays the playbooks in a responsive grid or list.
  - `PlaybookCard.vue`: A detailed card for each playbook, built on `BaseWidget`, showing all key stats.
- A reusable `DoughnutChart.vue` component was created with SVG to visualize the win rate.
- A placeholder `PlaybookDetailView.vue` has been created to handle navigation to individual playbooks.

The layout is fully responsive, with a two-column grid on desktop that collapses to a single column on mobile, and the layout switchers are hidden on smaller screens as per the requirements.