### PR TITLE
refactor: separazione rotte e controller per Trades

### DIFF
--- a/backend/app/Controllers/trades_controller.py
+++ b/backend/app/Controllers/trades_controller.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 from typing import List, Optional
 from uuid import UUID
-from fastapi import APIRouter, Depends, HTTPException, status
+from datetime import date
+
+from fastapi import HTTPException, status
 
 from app.Services.trade_service import TradeService
 from app.Services.analytics_service import AnalyticsService
@@ -14,159 +16,136 @@ from app.Schemas.analytics import (
     ProcessedStats,
     VantageScoreData,
     EquityCurveData,
-    TradeSummary
-)
-from app.Router.auth import get_current_claims
-from datetime import date
-
-router = APIRouter(
-    prefix="/trades",
-    tags=["Trades"],
-    responses={404: {"description": "Not found"}},
+    TradeSummary,
 )
 
 
-# --- Endpoint di Analisi ---
-
-@router.get("/performance/metrics/{trading_account_id}", response_model=PerformanceMetrics)
-async def get_performance_metrics(
-    trading_account_id: UUID,
-    start_date: date,
-    end_date: date,
-    service: AnalyticsService = Depends(),
-):
-    return await service.get_performance_metrics(trading_account_id, start_date, end_date)
-
-@router.get("/calendar/data/{trading_account_id}", response_model=List[CalendarDayData])
-async def get_calendar_data(
-    trading_account_id: UUID,
-    start_date: date,
-    end_date: date,
-    user_timezone: str,
-    service: AnalyticsService = Depends(),
-):
-    return await service.get_calendar_data(trading_account_id, start_date, end_date, user_timezone)
-
-@router.get("/processed-stats/{trading_account_id}", response_model=ProcessedStats)
-async def get_processed_stats(
-    trading_account_id: UUID,
-    start_date: date,
-    end_date: date,
-    service: AnalyticsService = Depends(),
-):
-    return await service.get_processed_stats(trading_account_id, start_date, end_date)
-
-@router.get("/vantage-score/{trading_account_id}", response_model=VantageScoreData)
-async def get_vantage_score(
-    trading_account_id: UUID,
-    start_date: date,
-    end_date: date,
-    service: AnalyticsService = Depends(),
-):
-    return await service.get_vantage_score(trading_account_id, start_date, end_date)
-
-@router.get("/equity-curve/{trading_account_id}", response_model=EquityCurveData)
-async def get_equity_curve(
-    trading_account_id: UUID,
-    start_date: date,
-    end_date: date,
-    service: AnalyticsService = Depends(),
-):
-    return await service.get_equity_curve(trading_account_id, start_date, end_date)
-
-@router.get("/summary/{trading_account_id}", response_model=TradeSummary)
-async def get_trade_summary(
-    trading_account_id: UUID,
-    start_date: date,
-    end_date: date,
-    service: AnalyticsService = Depends(),
-):
-    return await service.get_trade_summary(trading_account_id, start_date, end_date)
-
-
-@router.post("/", response_model=TradeRead, status_code=status.HTTP_201_CREATED)
-async def create_trade(
-    trade_data: TradeCreate,
-    claims: dict = Depends(get_current_claims),
-    service: TradeService = Depends(),
-):
+class TradesController:
     """
-    Crea un nuovo Trade.
-    Il `trading_account_id` nel body determina a quale account appartiene.
-    Il servizio verificherà che l'utente sia il proprietario del trading account.
+    Controller puro: nessun APIRouter qui.
+    Riceve parametri dal router e delega ai Services.
+    Gestisce qui le HTTPException per tenere il router super snello.
     """
-    return await service.create_trade(claims, trade_data)
 
+    # --- Endpoints di Analisi ---
+    async def get_performance_metrics(
+        self,
+        trading_account_id: UUID,
+        start_date: date,
+        end_date: date,
+        service: AnalyticsService,
+    ) -> PerformanceMetrics:
+        return await service.get_performance_metrics(trading_account_id, start_date, end_date)
 
-@router.get("/by-trading-account/{trading_account_id}", response_model=List[TradeRead])
-async def get_trades_for_trading_account(
-    trading_account_id: UUID,
-    start_date: Optional[date] = None,
-    end_date: Optional[date] = None,
-    claims: dict = Depends(get_current_claims),
-    service: TradeService = Depends(),
-):
-    """
-    Recupera i trades per un specifico Trading Account, con filtro opzionale per data.
-    """
-    return await service.list_trades_by_trading_account(
-        claims=claims,
-        trading_account_id=trading_account_id,
-        start_date=start_date,
-        end_date=end_date
-    )
+    async def get_calendar_data(
+        self,
+        trading_account_id: UUID,
+        start_date: date,
+        end_date: date,
+        user_timezone: str,
+        service: AnalyticsService,
+    ) -> List[CalendarDayData]:
+        return await service.get_calendar_data(trading_account_id, start_date, end_date, user_timezone)
 
+    async def get_processed_stats(
+        self,
+        trading_account_id: UUID,
+        start_date: date,
+        end_date: date,
+        service: AnalyticsService,
+    ) -> ProcessedStats:
+        return await service.get_processed_stats(trading_account_id, start_date, end_date)
 
-@router.get("/{trade_id}", response_model=TradeRead)
-async def get_trade(
-    trade_id: UUID,
-    claims: dict = Depends(get_current_claims),
-    service: TradeService = Depends(),
-):
-    """
-    Recupera un singolo Trade per ID.
-    """
-    trade = await service.get_trade(claims, trade_id)
-    if not trade:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Trade non trovato o non appartenente all'utente.",
+    async def get_vantage_score(
+        self,
+        trading_account_id: UUID,
+        start_date: date,
+        end_date: date,
+        service: AnalyticsService,
+    ) -> VantageScoreData:
+        return await service.get_vantage_score(trading_account_id, start_date, end_date)
+
+    async def get_equity_curve(
+        self,
+        trading_account_id: UUID,
+        start_date: date,
+        end_date: date,
+        service: AnalyticsService,
+    ) -> EquityCurveData:
+        return await service.get_equity_curve(trading_account_id, start_date, end_date)
+
+    async def get_trade_summary(
+        self,
+        trading_account_id: UUID,
+        start_date: date,
+        end_date: date,
+        service: AnalyticsService,
+    ) -> TradeSummary:
+        return await service.get_trade_summary(trading_account_id, start_date, end_date)
+
+    # --- CRUD Trades ---
+    async def create_trade(
+        self,
+        claims: dict,
+        trade_data: TradeCreate,
+        service: TradeService,
+    ) -> TradeRead:
+        return await service.create_trade(claims, trade_data)
+
+    async def list_trades_for_trading_account(
+        self,
+        claims: dict,
+        trading_account_id: UUID,
+        start_date: Optional[date],
+        end_date: Optional[date],
+        service: TradeService,
+    ) -> list[TradeRead]:
+        return await service.list_trades_by_trading_account(
+            claims=claims,
+            trading_account_id=trading_account_id,
+            start_date=start_date,
+            end_date=end_date,
         )
-    return trade
 
+    async def get_trade(
+        self,
+        claims: dict,
+        trade_id: UUID,
+        service: TradeService,
+    ) -> TradeRead:
+        trade = await service.get_trade(claims, trade_id)
+        if not trade:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Trade non trovato o non appartenente all'utente.",
+            )
+        return trade
 
-@router.put("/{trade_id}", response_model=TradeRead)
-async def update_trade(
-    trade_id: UUID,
-    trade_data: TradeUpdate,
-    claims: dict = Depends(get_current_claims),
-    service: TradeService = Depends(),
-):
-    """
-    Aggiorna un Trade esistente.
-    """
-    updated_trade = await service.update_trade(claims, trade_id, trade_data)
-    if not updated_trade:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Trade non trovato o non appartenente all'utente.",
-        )
-    return updated_trade
+    async def update_trade(
+        self,
+        claims: dict,
+        trade_id: UUID,
+        trade_data: TradeUpdate,
+        service: TradeService,
+    ) -> TradeRead:
+        updated_trade = await service.update_trade(claims, trade_id, trade_data)
+        if not updated_trade:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Trade non trovato o non appartenente all'utente.",
+            )
+        return updated_trade
 
-
-@router.delete("/{trade_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_trade(
-    trade_id: UUID,
-    claims: dict = Depends(get_current_claims),
-    service: TradeService = Depends(),
-):
-    """
-    Elimina un Trade.
-    """
-    success = await service.delete_trade(claims, trade_id)
-    if not success:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Trade non trovato o non appartenente all'utente.",
-        )
-    return None
+    async def delete_trade(
+        self,
+        claims: dict,
+        trade_id: UUID,
+        service: TradeService,
+    ) -> None:
+        success = await service.delete_trade(claims, trade_id)
+        if not success:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Trade non trovato o non appartenente all'utente.",
+            )
+        return None

--- a/backend/app/Router/routes.py
+++ b/backend/app/Router/routes.py
@@ -328,10 +328,10 @@ router.include_router(
 # ──────────────────────────────────────────────────────────────────────────────
 # 💹 TRADES (protetto: user)
 # ──────────────────────────────────────────────────────────────────────────────
-from app.Controllers import trades_controller
+from app.Router import trades_router
 
 router.include_router(
-    trades_controller.router,
+    trades_router.router,
     prefix="/api/v1",
     dependencies=[Depends(get_current_claims)],
 )

--- a/backend/app/Router/trades_router.py
+++ b/backend/app/Router/trades_router.py
@@ -1,0 +1,148 @@
+# backend/app/Router/trades_router.py
+
+from __future__ import annotations
+
+from typing import List, Optional
+from uuid import UUID
+from datetime import date
+
+from fastapi import APIRouter, Depends, status
+
+from app.Controllers.trades_controller import TradesController
+from app.Services.trade_service import TradeService
+from app.Services.analytics_service import AnalyticsService
+from app.Router.auth import get_current_claims
+
+from app.Schemas.trade import TradeRead, TradeCreate, TradeUpdate
+from app.Schemas.analytics import (
+    PerformanceMetrics,
+    CalendarDayData,
+    ProcessedStats,
+    VantageScoreData,
+    EquityCurveData,
+    TradeSummary,
+)
+
+controller = TradesController()
+
+router = APIRouter(
+    prefix="/trades",
+    tags=["Trades"],
+    responses={404: {"description": "Not found"}},
+)
+
+# --- Endpoint di Analisi ---
+@router.get("/performance/metrics/{trading_account_id}", response_model=PerformanceMetrics)
+async def get_performance_metrics(
+    trading_account_id: UUID,
+    start_date: date,
+    end_date: date,
+    service: AnalyticsService = Depends(),
+):
+    return await controller.get_performance_metrics(trading_account_id, start_date, end_date, service)
+
+
+@router.get("/calendar/data/{trading_account_id}", response_model=List[CalendarDayData])
+async def get_calendar_data(
+    trading_account_id: UUID,
+    start_date: date,
+    end_date: date,
+    user_timezone: str,
+    service: AnalyticsService = Depends(),
+):
+    return await controller.get_calendar_data(trading_account_id, start_date, end_date, user_timezone, service)
+
+
+@router.get("/processed-stats/{trading_account_id}", response_model=ProcessedStats)
+async def get_processed_stats(
+    trading_account_id: UUID,
+    start_date: date,
+    end_date: date,
+    service: AnalyticsService = Depends(),
+):
+    return await controller.get_processed_stats(trading_account_id, start_date, end_date, service)
+
+
+@router.get("/vantage-score/{trading_account_id}", response_model=VantageScoreData)
+async def get_vantage_score(
+    trading_account_id: UUID,
+    start_date: date,
+    end_date: date,
+    service: AnalyticsService = Depends(),
+):
+    return await controller.get_vantage_score(trading_account_id, start_date, end_date, service)
+
+
+@router.get("/equity-curve/{trading_account_id}", response_model=EquityCurveData)
+async def get_equity_curve(
+    trading_account_id: UUID,
+    start_date: date,
+    end_date: date,
+    service: AnalyticsService = Depends(),
+):
+    return await controller.get_equity_curve(trading_account_id, start_date, end_date, service)
+
+
+@router.get("/summary/{trading_account_id}", response_model=TradeSummary)
+async def get_trade_summary(
+    trading_account_id: UUID,
+    start_date: date,
+    end_date: date,
+    service: AnalyticsService = Depends(),
+):
+    return await controller.get_trade_summary(trading_account_id, start_date, end_date, service)
+
+
+# --- CRUD Trades ---
+@router.post("/", response_model=TradeRead, status_code=status.HTTP_201_CREATED)
+async def create_trade(
+    trade_data: TradeCreate,
+    claims: dict = Depends(get_current_claims),
+    service: TradeService = Depends(),
+):
+    return await controller.create_trade(claims, trade_data, service)
+
+
+@router.get("/by-trading-account/{trading_account_id}", response_model=List[TradeRead])
+async def get_trades_for_trading_account(
+    trading_account_id: UUID,
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+    claims: dict = Depends(get_current_claims),
+    service: TradeService = Depends(),
+):
+    return await controller.list_trades_for_trading_account(
+        claims=claims,
+        trading_account_id=trading_account_id,
+        start_date=start_date,
+        end_date=end_date,
+        service=service,
+    )
+
+
+@router.get("/{trade_id}", response_model=TradeRead)
+async def get_trade(
+    trade_id: UUID,
+    claims: dict = Depends(get_current_claims),
+    service: TradeService = Depends(),
+):
+    return await controller.get_trade(claims, trade_id, service)
+
+
+@router.put("/{trade_id}", response_model=TradeRead)
+async def update_trade(
+    trade_id: UUID,
+    trade_data: TradeUpdate,
+    claims: dict = Depends(get_current_claims),
+    service: TradeService = Depends(),
+):
+    return await controller.update_trade(claims, trade_id, trade_data, service)
+
+
+@router.delete("/{trade_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_trade(
+    trade_id: UUID,
+    claims: dict = Depends(get_current_claims),
+    service: TradeService = Depends(),
+):
+    return await controller.delete_trade(claims, trade_id, service)


### PR DESCRIPTION
- spostata la definizione delle rotte da `app/Controllers/trades_controller.py`
  al nuovo file `app/Router/trades_router.py`
- mantenuta nel controller solo la logica applicativa e la gestione delle
  HTTPException
- reso il router super snello: contiene solo mapping degli endpoint e Depends
- aggiornato `app/Router/routes.py` per includere il nuovo `trades_router`

Questo refactor migliora la separazione delle responsabilità:
- i router definiscono solo le API FastAPI
- i controller gestiscono la logica applicativa
- i services rimangono responsabili della logica di dominio