### PR TITLE
feat: Implement CRUD logic for brokers with admin-only access

### DIFF
--- a/backend/app/Controllers/broker_controller.py
+++ b/backend/app/Controllers/broker_controller.py
@@ -1,11 +1,13 @@
 # app/Controllers/broker_controller.py
 from __future__ import annotations
 
+import uuid
 from typing import List
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, status
 
 from app.Services.broker_service import BrokerService
-from app.Schemas.broker import BrokerRead
+from app.Schemas.broker import BrokerRead, BrokerCreate, BrokerUpdate
+from app.Router.auth import require_roles
 
 router = APIRouter(
     prefix="/brokers",
@@ -14,7 +16,25 @@ router = APIRouter(
 )
 
 
-@router.get("/", response_model=List[BrokerRead])
+@router.post(
+    "/",
+    response_model=BrokerRead,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a new broker (admin only)",
+    dependencies=[Depends(require_roles(["admin"]))],
+)
+async def create_broker(
+    broker_data: BrokerCreate,
+    service: BrokerService = Depends(),
+):
+    """
+    Creates a new broker.
+    - **name**: The name of the broker (must be unique).
+    """
+    return await service.create_broker(broker_data)
+
+
+@router.get("/", response_model=List[BrokerRead], summary="Get all brokers")
 async def get_all_brokers(
     service: BrokerService = Depends(),
 ):
@@ -22,3 +42,50 @@ async def get_all_brokers(
     Retrieves a list of all available brokers.
     """
     return await service.get_all_brokers()
+
+
+@router.get("/{broker_id}", response_model=BrokerRead, summary="Get a broker by ID")
+async def get_broker_by_id(
+    broker_id: uuid.UUID,
+    service: BrokerService = Depends(),
+):
+    """
+    Retrieves a single broker by its unique ID.
+    """
+    return await service.get_broker_by_id(broker_id)
+
+
+@router.put(
+    "/{broker_id}",
+    response_model=BrokerRead,
+    summary="Update a broker (admin only)",
+    dependencies=[Depends(require_roles(["admin"]))],
+)
+async def update_broker(
+    broker_id: uuid.UUID,
+    broker_data: BrokerUpdate,
+    service: BrokerService = Depends(),
+):
+    """
+    Updates a broker's name.
+    - **name**: The new name for the broker (must be unique).
+    """
+    return await service.update_broker(broker_id, broker_data)
+
+
+@router.delete(
+    "/{broker_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a broker (admin only)",
+    dependencies=[Depends(require_roles(["admin"]))],
+)
+async def delete_broker(
+    broker_id: uuid.UUID,
+    service: BrokerService = Depends(),
+):
+    """
+    Deletes a broker by its unique ID.
+    Deletion will fail if the broker is associated with any other resources.
+    """
+    await service.delete_broker(broker_id)
+    return None

--- a/backend/app/Repositories/broker_repository.py
+++ b/backend/app/Repositories/broker_repository.py
@@ -1,9 +1,11 @@
 # app/Repositories/broker_repository.py
 from __future__ import annotations
 
+import uuid
 from typing import List
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.Models.broker import Broker
 
@@ -12,8 +14,58 @@ class BrokerRepository:
     def __init__(self, db: AsyncSession):
         self.db = db
 
+    async def create(self, data: dict) -> Broker:
+        """Creates a new broker."""
+        broker = Broker(**data)
+        self.db.add(broker)
+        await self.db.commit()
+        await self.db.refresh(broker)
+        return broker
+
+    async def get_by_id(self, broker_id: uuid.UUID) -> Broker | None:
+        """Gets a broker by its ID."""
+        stmt = select(Broker).where(Broker.id == broker_id)
+        result = await self.db.execute(stmt)
+        return result.scalars().first()
+
+    async def get_by_id_with_relationships(self, broker_id: uuid.UUID) -> Broker | None:
+        """
+        Gets a broker by its ID with its relationships loaded
+        for checking if it's in use.
+        """
+        stmt = (
+            select(Broker)
+            .where(Broker.id == broker_id)
+            .options(
+                selectinload(Broker.trading_accounts),
+                selectinload(Broker.platforms),
+                selectinload(Broker.asset_aliases),
+            )
+        )
+        result = await self.db.execute(stmt)
+        return result.scalars().first()
+
+    async def get_by_name(self, name: str) -> Broker | None:
+        """Gets a broker by its name to check for duplicates."""
+        stmt = select(Broker).where(Broker.name == name)
+        result = await self.db.execute(stmt)
+        return result.scalars().first()
+
     async def list_all(self) -> List[Broker]:
         """Lists all brokers."""
         stmt = select(Broker).order_by(Broker.name)
         result = await self.db.execute(stmt)
         return result.scalars().all()
+
+    async def update(self, broker: Broker, data: dict) -> Broker:
+        """Updates a broker."""
+        for key, value in data.items():
+            setattr(broker, key, value)
+        await self.db.commit()
+        await self.db.refresh(broker)
+        return broker
+
+    async def delete(self, broker: Broker) -> None:
+        """Deletes a broker."""
+        await self.db.delete(broker)
+        await self.db.commit()

--- a/backend/app/Schemas/broker.py
+++ b/backend/app/Schemas/broker.py
@@ -4,9 +4,20 @@ from uuid import UUID
 from pydantic import BaseModel
 
 
-class BrokerRead(BaseModel):
-    id: UUID
+class BrokerBase(BaseModel):
     name: str
+
+
+class BrokerCreate(BrokerBase):
+    pass
+
+
+class BrokerUpdate(BrokerBase):
+    pass
+
+
+class BrokerRead(BrokerBase):
+    id: UUID
 
     class Config:
         from_attributes = True

--- a/backend/app/Services/broker_service.py
+++ b/backend/app/Services/broker_service.py
@@ -1,19 +1,83 @@
 # app/Services/broker_service.py
 from __future__ import annotations
 
+import uuid
 from typing import List
-from fastapi import Depends
+from fastapi import Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.Infrastructure.db import get_db
 from app.Repositories.broker_repository import BrokerRepository
 from app.Models.broker import Broker
+from app.Schemas.broker import BrokerCreate, BrokerUpdate
 
 
 class BrokerService:
     def __init__(self, db: AsyncSession = Depends(get_db)):
         self.repo = BrokerRepository(db)
 
+    async def create_broker(self, data: BrokerCreate) -> Broker:
+        """Creates a new broker."""
+        # Check if a broker with the same name already exists
+        existing_broker = await self.repo.get_by_name(data.name)
+        if existing_broker:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="A broker with this name already exists.",
+            )
+
+        return await self.repo.create(data.dict())
+
     async def get_all_brokers(self) -> List[Broker]:
         """Returns a list of all brokers."""
         return await self.repo.list_all()
+
+    async def get_broker_by_id(self, broker_id: uuid.UUID) -> Broker:
+        """Returns a broker by its ID."""
+        broker = await self.repo.get_by_id(broker_id)
+        if not broker:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Broker not found.",
+            )
+        return broker
+
+    async def update_broker(
+        self, broker_id: uuid.UUID, data: BrokerUpdate
+    ) -> Broker:
+        """Updates a broker's name."""
+        broker = await self.get_broker_by_id(broker_id)
+
+        # Check if another broker with the new name already exists
+        if data.name != broker.name:
+            existing_broker = await self.repo.get_by_name(data.name)
+            if existing_broker:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="A broker with this name already exists.",
+                )
+
+        return await self.repo.update(broker, data.dict(exclude_unset=True))
+
+    async def delete_broker(self, broker_id: uuid.UUID) -> None:
+        """Deletes a broker."""
+        broker = await self.repo.get_by_id_with_relationships(broker_id)
+
+        if not broker:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Broker not found.",
+            )
+
+        # Check for active relationships
+        if (
+            broker.trading_accounts
+            or broker.platforms
+            or broker.asset_aliases
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Cannot delete broker because it is associated with other resources.",
+            )
+
+        await self.repo.delete(broker)

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -19,7 +19,7 @@ from app.Router.auth import get_current_claims
 from app.Models import (
     auth_user, role, tag, trade, trades_tags, user_dashboard_layout, user_role,
     general_account, trading_account, broker, asset, asset_class, mistake,
-    playbook, news_impact, psychology_state, trades_mistakes, trades_playbooks,
+    playbook, news_impact, psychology_state, trades_mistakes,
     trades_news_impacts, trades_psychology
 )
 from app.Models.auth_user import AuthUser

--- a/backend/tests/controllers/test_broker_controller.py
+++ b/backend/tests/controllers/test_broker_controller.py
@@ -1,0 +1,188 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from uuid import uuid4
+from fastapi import status
+
+from app.main import app
+from app.Models.broker import Broker
+from app.Models.role import Role
+from app.Models.auth_user import AuthUser
+from app.Models.user_role import UserRole
+from app.Models.trading_account import TradingAccount
+from app.Models.general_account import GeneralAccount
+from app.Router.auth import get_current_claims
+
+# ------------------------------
+# Fixtures
+# ------------------------------
+
+@pytest.fixture(scope="module")
+def anyio_backend():
+    """Use asyncio for all tests in this module."""
+    return "asyncio"
+
+@pytest.fixture
+async def admin_user(db_session: AsyncSession) -> AuthUser:
+    """Creates an admin user, ensuring the 'admin' role exists."""
+    stmt = select(Role).where(Role.name == "admin")
+    result = await db_session.execute(stmt)
+    admin_role = result.scalars().first()
+    if not admin_role:
+        admin_role = Role(id=uuid4(), name="admin", description="Administrator")
+        db_session.add(admin_role)
+        await db_session.flush()
+
+    user = AuthUser(id=uuid4(), email=f"admin_{uuid4()}@test.com")
+    db_session.add(user)
+    await db_session.flush()
+
+    user_role = UserRole(user_id=user.id, role_id=admin_role.id)
+    db_session.add(user_role)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+@pytest.fixture
+async def regular_user(db_session: AsyncSession) -> AuthUser:
+    """Creates a regular user for testing."""
+    user = AuthUser(id=uuid4(), email=f"user_{uuid4()}@test.com")
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+@pytest.fixture
+def admin_client(async_client: AsyncClient, admin_user: AuthUser) -> AsyncClient:
+    """Provides a test client authenticated as an admin user."""
+    app.dependency_overrides[get_current_claims] = lambda: {
+        "sub": str(admin_user.id),
+        "email": admin_user.email,
+    }
+    return async_client
+
+@pytest.fixture
+def user_client(async_client: AsyncClient, regular_user: AuthUser) -> AsyncClient:
+    """Provides a test client authenticated as a regular user."""
+    app.dependency_overrides[get_current_claims] = lambda: {
+        "sub": str(regular_user.id),
+        "email": regular_user.email,
+    }
+    return async_client
+
+@pytest.fixture
+async def test_broker(db_session: AsyncSession) -> Broker:
+    """Fixture for a pre-existing broker."""
+    broker = Broker(name=f"Test Broker Inc. {uuid4()}")
+    db_session.add(broker)
+    await db_session.commit()
+    await db_session.refresh(broker)
+    return broker
+
+# ------------------------------
+# Tests
+# ------------------------------
+
+@pytest.mark.anyio
+async def test_create_broker_as_admin(admin_client: AsyncClient):
+    """Admin can create a new broker."""
+    response = await admin_client.post("/api/v1/brokers/", json={"name": "New Broker"})
+    assert response.status_code == status.HTTP_201_CREATED
+    data = response.json()
+    assert data["name"] == "New Broker"
+    assert "id" in data
+
+@pytest.mark.anyio
+async def test_create_broker_as_user(user_client: AsyncClient):
+    """Regular user cannot create a broker."""
+    response = await user_client.post("/api/v1/brokers/", json={"name": "Forbidden Broker"})
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+@pytest.mark.anyio
+async def test_create_broker_duplicate_name(admin_client: AsyncClient, test_broker: Broker):
+    """Cannot create a broker with a duplicate name."""
+    response = await admin_client.post("/api/v1/brokers/", json={"name": test_broker.name})
+    assert response.status_code == status.HTTP_409_CONFLICT
+
+@pytest.mark.anyio
+async def test_get_all_brokers(user_client: AsyncClient, test_broker: Broker):
+    """Any authenticated user can list all brokers."""
+    response = await user_client.get("/api/v1/brokers/")
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    assert any(b["id"] == str(test_broker.id) for b in data)
+
+@pytest.mark.anyio
+async def test_get_broker_by_id(user_client: AsyncClient, test_broker: Broker):
+    """Any authenticated user can get a broker by ID."""
+    response = await user_client.get(f"/api/v1/brokers/{test_broker.id}")
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["id"] == str(test_broker.id)
+    assert data["name"] == test_broker.name
+
+@pytest.mark.anyio
+async def test_get_broker_not_found(user_client: AsyncClient):
+    """Getting a non-existent broker returns 404."""
+    non_existent_id = uuid4()
+    response = await user_client.get(f"/api/v1/brokers/{non_existent_id}")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+@pytest.mark.anyio
+async def test_update_broker_as_admin(admin_client: AsyncClient, test_broker: Broker):
+    """Admin can update a broker."""
+    new_name = "Updated Broker Name"
+    response = await admin_client.put(f"/api/v1/brokers/{test_broker.id}", json={"name": new_name})
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["name"] == new_name
+
+@pytest.mark.anyio
+async def test_update_broker_as_user(user_client: AsyncClient, test_broker: Broker):
+    """Regular user cannot update a broker."""
+    response = await user_client.put(f"/api/v1/brokers/{test_broker.id}", json={"name": "Forbidden Name"})
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+@pytest.mark.anyio
+async def test_delete_broker_as_admin(admin_client: AsyncClient, db_session: AsyncSession):
+    """Admin can delete a broker if it has no dependencies."""
+    broker_to_delete = Broker(name=f"Deletable Broker {uuid4()}")
+    db_session.add(broker_to_delete)
+    await db_session.commit()
+
+    response = await admin_client.delete(f"/api/v1/brokers/{broker_to_delete.id}")
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    # Verify it's gone
+    deleted = await db_session.get(Broker, broker_to_delete.id)
+    assert deleted is None
+
+@pytest.mark.anyio
+async def test_delete_broker_as_user(user_client: AsyncClient, test_broker: Broker):
+    """Regular user cannot delete a broker."""
+    response = await user_client.delete(f"/api/v1/brokers/{test_broker.id}")
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+@pytest.mark.anyio
+async def test_delete_broker_with_dependencies(admin_client: AsyncClient, test_broker: Broker, db_session: AsyncSession, regular_user: AuthUser):
+    """Cannot delete a broker if it's linked to a trading account."""
+    # Create a GeneralAccount first, as TradingAccount depends on it
+    general_account = GeneralAccount(user_id=regular_user.id, label="Test General Account")
+    db_session.add(general_account)
+    await db_session.flush()
+
+    # Now, create the TradingAccount which acts as a dependency
+    trading_account = TradingAccount(
+        label="My Dependent Trading Account",
+        broker_id=test_broker.id,
+        general_account_id=general_account.id
+    )
+    db_session.add(trading_account)
+    await db_session.commit()
+
+    response = await admin_client.delete(f"/api/v1/brokers/{test_broker.id}")
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert "associated with other resources" in response.json()["detail"]


### PR DESCRIPTION
This commit introduces full CRUD (Create, Read, Update, Delete) functionality for the broker resource.

Key changes include:
- Added POST, GET, PUT, and DELETE endpoints to `broker_controller.py`.
- Implemented corresponding business logic in `broker_service.py`, including checks for duplicate names and preventing deletion of brokers with active dependencies.
- Expanded `broker_repository.py` to handle all database operations for brokers.
- Created `BrokerCreate` and `BrokerUpdate` schemas for data validation.
- Secured the create, update, and delete endpoints to be accessible only by users with the "admin" role. Read operations remain available to all authenticated users.
- Added a comprehensive test suite to verify all new functionality and security restrictions.