### PR TITLE
feat: Build Playbook Detail Page

### DIFF
--- a/frontend/src/components/analytics/MetricItem.vue
+++ b/frontend/src/components/analytics/MetricItem.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="metric-item">
+    <HeaderInfoOverlay :aria-label="`Learn more about ${info.title}`">
+      <template #title>
+        <span class="metric-label">{{ label }}</span>
+      </template>
+      <template #content>
+        <h4 class="info-overlay-title">{{ info.title }}</h4>
+        <p class="info-overlay-text">{{ info.description }}</p>
+      </template>
+    </HeaderInfoOverlay>
+    <p class="metric-value">{{ value }}</p>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import HeaderInfoOverlay from '@/components/ui/HeaderInfoOverlay.vue';
+import { useMetricInfo } from '@/composables/useMetricInfo.js';
+
+const props = defineProps({
+  label: { type: String, required: true },
+  value: { type: [String, Number], required: true },
+  metricKey: { type: String, required: true },
+});
+
+const { info } = useMetricInfo(props.metricKey);
+</script>
+
+<style scoped>
+.metric-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--semantic-size-stack-xxs);
+}
+
+.metric-label {
+  font: var(--semantic-font-style-body-sm);
+  color: var(--semantic-color-text-secondary);
+}
+
+.metric-value {
+  font: var(--semantic-font-style-heading-lg);
+  color: var(--semantic-color-text-primary);
+  font-weight: 600;
+}
+
+.metric-item :deep(.title-container) {
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--semantic-size-stack-xxs);
+}
+
+.info-overlay-title {
+  font: var(--semantic-font-style-label-md);
+  color: var(--semantic-color-text-primary);
+}
+
+.info-overlay-text {
+  font: var(--semantic-font-style-body-sm);
+  color: var(--semantic-color-text-secondary);
+  line-height: var(--base-font-line-height-tight);
+}
+</style>

--- a/frontend/src/views/PlaybookDetailView.vue
+++ b/frontend/src/views/PlaybookDetailView.vue
@@ -41,7 +41,13 @@
             </button>
         </div>
         <div class="metrics-grid">
-            <StatCard v-for="metric in formattedMetrics" :key="metric.key" :stat="metric" />
+            <MetricItem
+              v-for="metric in formattedMetrics"
+              :key="metric.key"
+              :label="metric.label"
+              :value="metric.value"
+              :metricKey="metric.key"
+            />
         </div>
 
         <div class="chart-section">
@@ -60,7 +66,7 @@
 import { onMounted, computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { usePlaybookStore } from '@/stores/playbookStore';
-import StatCard from '@/components/dashboard/widgets/StatCard/index.vue';
+import MetricItem from '@/components/analytics/MetricItem.vue';
 import BaseButton from '@/components/ui/BaseButton.vue';
 import { formatCurrency, formatNumber, formatPercentage } from '@/services/formatters.js';
 import { Line } from 'vue-chartjs';


### PR DESCRIPTION
This commit introduces the new Playbook Detail page, which provides users with in-depth analytics for a specific playbook.

Key features include:
- A new backend endpoint (`/api/v1/playbooks/{playbook_id}/analytics`) that calculates and serves all necessary data.
- A redesigned `PlaybookDetailView.vue` component that displays the analytics data in a user-friendly interface.
- The entire analytics section is enclosed in a single card container.
- Metrics are displayed using a new, lightweight `MetricItem` component to match the design, removing the previous card-based layout.
- A "Daily Net Cumulative P&L" line chart, implemented using `vue-chartjs`.
- The page is fully responsive.
- A new `formatters.js` service was created to centralize data formatting and fix an import bug.