### PR TITLE
feat(playbooks): Implement conditional 3-column layout for playbook c…

### DIFF
--- a/frontend/src/components/Playbooks/PlaybookCard.vue
+++ b/frontend/src/components/Playbooks/PlaybookCard.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { defineProps } from 'vue';
+import { defineProps, computed } from 'vue';
 import BaseWidget from '../layout/BaseWidget.vue';
 import DoughnutChart from './DoughnutChart.vue';
 import { formatCurrency } from '@/services/formatters.js';
@@ -9,6 +9,14 @@ const props = defineProps({
     type: Object,
     required: true,
   },
+  layout: {
+    type: String,
+    default: 'grid',
+  },
+});
+
+const statsGridClass = computed(() => {
+  return props.layout === 'grid' ? 'layout-grid' : '';
 });
 </script>
 
@@ -22,7 +30,7 @@ const props = defineProps({
         </div>
       </template>
 
-      <div class="stats-grid">
+      <div class="stats-grid" :class="statsGridClass">
         <!-- Win Rate with Doughnut Chart -->
         <div class="stat-item win-rate-stat">
           <div class="donut-chart-container">
@@ -104,6 +112,11 @@ const props = defineProps({
   /* Use the widget's content padding, no extra top padding needed */
   padding: var(--semantic-size-inset-lg);
   padding-top: var(--semantic-size-stack-lg);
+}
+
+/* When in grid view, force a 3-column layout for the stats */
+.stats-grid.layout-grid {
+  grid-template-columns: repeat(3, 1fr);
 }
 
 .stat-item {

--- a/frontend/src/components/Playbooks/PlaybookList.vue
+++ b/frontend/src/components/Playbooks/PlaybookList.vue
@@ -10,6 +10,7 @@
       v-for="playbook in playbooks"
       :key="playbook.id"
       :playbook="playbook"
+      :layout="layout"
     />
   </div>
 </template>


### PR DESCRIPTION
…ard stats

This change addresses a specific UI requirement to control the layout of the statistics grid within the playbook cards based on the parent view's layout setting.

- The `layout` prop (e.g., 'grid' or 'list') is now passed from `PlaybooksView.vue` through `PlaybookList.vue` down to each `PlaybookCard.vue` component.
- `PlaybookCard.vue` now accepts the `layout` prop and uses it to conditionally apply a `.layout-grid` CSS class to the stats container.
- A new CSS rule, `.stats-grid.layout-grid`, has been added to force `grid-template-columns: repeat(3, 1fr);`, ensuring a fixed 3-column layout for the stats only when the user selects the grid view.
- The default layout for the stats remains responsive (`auto-fit`), preserving the correct behavior for list and mobile views.