### PR TITLE
fix: Refactor chart configuration to correctly render doughnut chart

### DIFF
--- a/frontend/src/components/KpiDashboard.vue
+++ b/frontend/src/components/KpiDashboard.vue
@@ -137,8 +137,8 @@ const pnlLineChartOptions = {
   scales: { x: { display: false }, y: { display: false } },
 };
 
-// 2. Gauge Charts (Profit Factor & Win %)
-const createGaugeData = (value, max) => {
+// 2. Meter Charts (Doughnut/Gauge) - Refactored for clarity
+const createMeterData = (value, max) => {
   const normalizedValue = Math.min(Math.max(value, 0), max);
   return {
     datasets: [{
@@ -148,20 +148,28 @@ const createGaugeData = (value, max) => {
         `rgba(${getRgbValues(tertiaryColor.value)}, 0.2)`,
       ],
       borderWidth: 0,
-      circumference: 180,
-      rotation: 270,
     }]
   };
 };
 
-const profitFactorGaugeData = computed(() => createGaugeData(summaryData.value?.stats?.profit_factor || 0, 10));
-const winPercentageGaugeData = computed(() => createGaugeData(summaryData.value?.stats?.win_rate || 0, 100));
+const profitFactorChartData = computed(() => createMeterData(summaryData.value?.stats?.profit_factor || 0, 10));
+const winPercentageChartData = computed(() => createMeterData(summaryData.value?.stats?.win_rate || 0, 100));
 
 const gaugeOptions = {
   responsive: true,
   maintainAspectRatio: false,
   cutout: '80%',
-  plugins: { tooltip: { enabled: false } }
+  plugins: { tooltip: { enabled: false } },
+  circumference: 180, // Presentation option for semi-circle
+  rotation: 270,      // Presentation option for semi-circle
+};
+
+const doughnutOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  cutout: '80%',
+  plugins: { tooltip: { enabled: false } },
+  circumference: 360, // Presentation option for full circle
 };
 
 
@@ -227,7 +235,7 @@ const barOptions = {
         <p class="metric-value">{{ summaryData.stats.profit_factor.toFixed(2) }}</p>
       </div>
       <div class="chart-content gauge-chart-wrapper">
-        <GaugeChart :chart-data="profitFactorGaugeData" :chart-options="gaugeOptions" />
+        <GaugeChart :chart-data="profitFactorChartData" :chart-options="doughnutOptions" />
       </div>
     </KpiCard>
 
@@ -238,7 +246,7 @@ const barOptions = {
         <p class="metric-value">{{ summaryData.stats.win_rate.toFixed(2) }}%</p>
       </div>
       <div class="chart-content gauge-chart-wrapper">
-        <GaugeChart :chart-data="winPercentageGaugeData" :chart-options="gaugeOptions" />
+        <GaugeChart :chart-data="winPercentageChartData" :chart-options="gaugeOptions" />
       </div>
     </KpiCard>
 


### PR DESCRIPTION
This commit provides the definitive fix for the Profit Factor chart visualization.

The root cause of the bug was an incorrect separation of concerns. The data generation logic was mixed with presentational options, causing the doughnut chart to render incorrectly as a semi-circle.

This fix refactors the chart configuration by:
1.  Consolidating the data preparation logic into a single, generic `createMeterData` function.
2.  Moving the presentational options (`circumference: 180`, `rotation: 270`) into the `gaugeOptions` object, where they belong.
3.  Ensuring the "Profit Factor" chart uses the `doughnutOptions` (with `circumference: 360`) and the "Win %" chart uses the `gaugeOptions`.

This resolves the visual bug and makes the component's code cleaner and more maintainable.